### PR TITLE
don't auto revoke Network and Sensors permission

### DIFF
--- a/src/com/android/permissioncontroller/permission/data/AutoRevokeStateLiveData.kt
+++ b/src/com/android/permissioncontroller/permission/data/AutoRevokeStateLiveData.kt
@@ -29,6 +29,7 @@ import com.android.permissioncontroller.permission.service.ExemptServicesLiveDat
 import com.android.permissioncontroller.permission.service.isAutoRevokeEnabled
 import com.android.permissioncontroller.permission.service.isPackageAutoRevokeExempt
 import com.android.permissioncontroller.permission.service.isPackageAutoRevokePermanentlyExempt
+import com.android.permissioncontroller.permission.utils.Utils
 import kotlinx.coroutines.Job
 
 /**
@@ -91,7 +92,7 @@ class AutoRevokeStateLiveData private constructor(
                     permState.permFlags and (FLAG_PERMISSION_GRANTED_BY_DEFAULT or
                             FLAG_PERMISSION_GRANTED_BY_ROLE) != 0
                 } ?: false
-                if (!default) {
+                if (!default && !Utils.isSpecialRuntimePermissionGroup(groupName)) {
                     revocableGroups.add(groupName)
                 }
             }

--- a/src/com/android/permissioncontroller/permission/service/AutoRevokePermissions.kt
+++ b/src/com/android/permissioncontroller/permission/service/AutoRevokePermissions.kt
@@ -231,8 +231,7 @@ class AutoRevokeOnBootReceiver : BroadcastReceiver() {
 private suspend fun revokePermissionsOnUnusedApps(
     context: Context,
     sessionId: Long = INVALID_SESSION_ID
-):
-    List<Pair<String, UserHandle>> {
+): List<Pair<String, UserHandle>> {
     if (!isAutoRevokeEnabled(context)) {
         return emptyList()
     }
@@ -353,7 +352,8 @@ private suspend fun revokePermissionsOnUnusedApps(
                     granted &&
                     !group.isGrantedByDefault &&
                     !group.isGrantedByRole &&
-                    group.isUserSensitive) {
+                    group.isUserSensitive &&
+                    !Utils.isSpecialRuntimePermissionGroup(groupName)) {
 
                     val revocablePermissions = group.permissions.keys.toList()
 

--- a/src/com/android/permissioncontroller/permission/utils/Utils.java
+++ b/src/com/android/permissioncontroller/permission/utils/Utils.java
@@ -663,6 +663,17 @@ public final class Utils {
     }
 
     /**
+     * Is the permission group a special runtime permission group?
+     * These are treated as a runtime permission even for legacy apps. They
+     * need to be granted by default for all apps to maintain compatibility.
+     *
+     * @return whether the permission group is a special runtime permission group.
+     */
+    public static boolean isSpecialRuntimePermissionGroup(@NonNull String permissionGroup) {
+        return SPECIAL_RUNTIME_PERMISSIONS.containsValue(permissionGroup);
+    }
+
+    /**
      * Should UI show this permission.
      *
      * <p>If the user cannot change the group, it should not be shown.


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os_issue_tracker/issues/323

Decided not to mess with the FLAG_PERMISSION_GRANTED_BY_DEFAULT flag.

UI no longer display Network and Sensors in the footer list of permissions that will be auto revoked.
The Job that handles the auto revoking no longer revoke Network and Sensors.

### Test: 
During testing, the time periods and inactive threshold in AutoRevokePermissions.kt to force earlier auto revoking.

This is the result after enabling every permission (including Network and Sensors) for every app in the app drawer. Installed some third-party apps beforehand

|(1) Getting the notification|(2) Tapping on the notification| |
|---|---|---|
|![perms-1](https://user-images.githubusercontent.com/26474149/93420097-1ff7b680-f863-11ea-9f16-f830e6b20544.png)|![perms-2a](https://user-images.githubusercontent.com/26474149/93420135-3b62c180-f863-11ea-879c-04aa43eebb51.png)| ![perms-2b](https://user-images.githubusercontent.com/26474149/93420167-4ae20a80-f863-11ea-9289-ed3d8195035f.png)

|(3) Looking at APKMirror|(4) Enabling a permission to see the footer at bottom change properly|
|---|---|
|![perms-3a](https://user-images.githubusercontent.com/26474149/93420204-5d5c4400-f863-11ea-95e2-8d8cbced0d9e.png)|![perms-3b](https://user-images.githubusercontent.com/26474149/93420210-61886180-f863-11ea-80b8-843f955e2645.png)|

