### PR TITLE
sscopes: bugfix: storage permissions for preinstalled apps came back after OS update

### DIFF
--- a/PermissionController/src/com/android/permissioncontroller/sscopes/StorageScopesUtils.java
+++ b/PermissionController/src/com/android/permissioncontroller/sscopes/StorageScopesUtils.java
@@ -307,6 +307,8 @@ public class StorageScopesUtils {
             if (targetSdk >= 23) { // runtime permissions are always granted for targetSdk < 23 apps
                 if (pm.checkPermission(permission, pkgName) == PackageManager.PERMISSION_GRANTED) {
                     pm.revokeRuntimePermission(pkgName, permission, user, "StorageScopes");
+                    int permFlag = PackageManager.FLAG_PERMISSION_USER_SET;
+                    pm.updatePermissionFlags(permission, pkgName, permFlag, permFlag, user);
                     ++ numOfRevokations;
                 }
             }


### PR DESCRIPTION
During OS update, code that pregrants default permissions to preinstalled apps is executed.
It checks for FLAG_PERMISSION_USER_SET, and if it's missing, permission will be granted again.
