### PR TITLE
sscopes: remove empty UI element from custom permission request dialogs

### DIFF
--- a/PermissionController/src/com/android/permissioncontroller/sscopes/BroadStorageAccessPromptActivity.java
+++ b/PermissionController/src/com/android/permissioncontroller/sscopes/BroadStorageAccessPromptActivity.java
@@ -87,6 +87,9 @@ public class BroadStorageAccessPromptActivity extends SettingsActivity implement
 
         View root = LayoutInflater.from(this).inflate(R.layout.grant_permissions_material3, null);
 
+        // not applicable, this is a custom permission dialog
+        root.requireViewById(R.id.permission_rationale_container).setVisibility(View.GONE);
+
         SecureButton allowButton = root.requireViewById(R.id.permission_allow_button);
         allowButton.setText(R.string.grant_dialog_button_allow_in_settings);
 


### PR DESCRIPTION
This applies to "All files access" and MANAGE_MEDIA special access permission dialogs.