### PR TITLE
Backport health permission UI related fixes from AOSP

### DIFF
--- a/PermissionController/src/com/android/permissioncontroller/permission/data/AppPermGroupUiInfoLiveData.kt
+++ b/PermissionController/src/com/android/permissioncontroller/permission/data/AppPermGroupUiInfoLiveData.kt
@@ -62,6 +62,7 @@ class AppPermGroupUiInfoLiveData private constructor(
     private val permGroupLiveData = PermGroupLiveData[permGroupName]
     private val permissionStateLiveData = PermStateLiveData[packageName, permGroupName, user]
     private val isStorage = permGroupName == STORAGE
+    private val isHealth = Utils.isHealthPermissionGroup(permGroupName)
 
     init {
         isSpecialLocation = LocationUtils.isLocationGroupAndProvider(app,
@@ -127,7 +128,8 @@ class AppPermGroupUiInfoLiveData private constructor(
 
         val shouldShow = packageInfo.enabled &&
             isGrantableAndNotLegacyPlatform(packageInfo, groupInfo, requestedPermissionInfos) &&
-            (!isStorage || Utils.shouldShowStorage(packageInfo))
+            (!isStorage || Utils.shouldShowStorage(packageInfo)) &&
+            (!isHealth || Utils.shouldShowHealthPermission(packageInfo, groupInfo.name))
 
         val isSystemApp = !isUserSensitive(permissionState)
 

--- a/PermissionController/src/com/android/permissioncontroller/permission/ui/model/AllAppPermissionsViewModel.kt
+++ b/PermissionController/src/com/android/permissioncontroller/permission/ui/model/AllAppPermissionsViewModel.kt
@@ -81,6 +81,8 @@ class AllAppPermissionsViewModel(
                 .filter { filterGroup == null || it.key == filterGroup }
                 .filter { (it.key != Manifest.permission_group.STORAGE ||
                         Utils.shouldShowStorage(packageInfo)) }
+                .filter { (!Utils.isHealthPermissionGroup(it.key) ||
+                        Utils.shouldShowHealthPermission(packageInfo, it.key))}
         }
     }
 }

--- a/PermissionController/src/com/android/permissioncontroller/permission/ui/model/GrantPermissionsViewModel.kt
+++ b/PermissionController/src/com/android/permissioncontroller/permission/ui/model/GrantPermissionsViewModel.kt
@@ -43,7 +43,6 @@ import android.os.UserManager
 import android.permission.PermissionManager
 import android.provider.MediaStore
 import android.util.Log
-import androidx.annotation.ChecksSdkIntAtLeast
 import androidx.core.util.Consumer
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -622,7 +621,7 @@ class GrantPermissionsViewModel(
             if (rhsHasOneTime && !lhsHasOneTime) {
                 -1
             } else if ((!rhsHasOneTime && lhsHasOneTime) ||
-                isHealthPermissionGroup(rhs.groupName)
+                Utils.isHealthPermissionGroup(rhs.groupName)
             ) {
                 1
             } else {
@@ -1281,11 +1280,6 @@ class GrantPermissionsViewModel(
                 true
             }
         }
-    }
-
-    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
-    private fun isHealthPermissionGroup(permGroupName: String): Boolean {
-        return SdkLevel.isAtLeastU() && HEALTH_PERMISSION_GROUP.equals(permGroupName)
     }
 
     fun handleHealthConnectPermissions(activity: Activity) {

--- a/PermissionController/src/com/android/permissioncontroller/permission/utils/Utils.java
+++ b/PermissionController/src/com/android/permissioncontroller/permission/utils/Utils.java
@@ -42,6 +42,7 @@ import static android.content.pm.PackageManager.FLAG_PERMISSION_USER_SENSITIVE_W
 import static android.content.pm.PackageManager.FLAG_PERMISSION_USER_SENSITIVE_WHEN_GRANTED;
 import static android.content.pm.PackageManager.MATCH_SYSTEM_ONLY;
 import static android.health.connect.HealthConnectManager.ACTION_MANAGE_HEALTH_PERMISSIONS;
+import static android.health.connect.HealthPermissions.HEALTH_PERMISSION_GROUP;
 import static android.os.UserHandle.myUserId;
 
 import static com.android.permissioncontroller.Constants.EXTRA_SESSION_ID;
@@ -73,6 +74,7 @@ import android.graphics.Bitmap;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.hardware.SensorPrivacyManager;
+import android.health.connect.HealthConnectManager;
 import android.os.Binder;
 import android.os.Build;
 import android.os.Parcelable;
@@ -109,6 +111,8 @@ import com.android.permissioncontroller.permission.model.AppPermissionGroup;
 import com.android.permissioncontroller.permission.model.livedatatypes.LightAppPermGroup;
 import com.android.permissioncontroller.permission.model.livedatatypes.LightPackageInfo;
 
+import kotlin.Triple;
+
 import java.lang.annotation.Retention;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
@@ -119,8 +123,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Random;
 import java.util.Set;
-
-import kotlin.Triple;
 
 public final class Utils {
 
@@ -940,6 +942,70 @@ public final class Utils {
         } finally {
             Binder.restoreCallingIdentity(token);
         }
+    }
+
+    /**
+     * Returns true if the group name passed is that of the Platform health group.
+     * @param permGroupName name of the group that needs to be checked.
+     */
+    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    public static Boolean isHealthPermissionGroup(String permGroupName) {
+        return SdkLevel.isAtLeastU() && HEALTH_PERMISSION_GROUP.equals(permGroupName);
+    }
+
+    /**
+     * Return whether health permission setting entry should be shown or not
+     *
+     * Should not show Health permissions preference if the package doesn't handle
+     * VIEW_PERMISSION_USAGE_INTENT.
+     *
+     * Will show if above is true AND permission is already granted.
+     *
+     * @param packageInfo the {@link PackageInfo} app which uses the permission
+     * @param permGroupName the health permission group name to show
+     * @return {@code TRUE} iff health permission should be shown
+     */
+    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    public static Boolean shouldShowHealthPermission(LightPackageInfo packageInfo,
+            String permGroupName) {
+        if (!isHealthPermissionGroup(permGroupName)) {
+            return false;
+        }
+
+        PermissionControllerApplication app = PermissionControllerApplication.get();
+        PackageManager pm = app.getPackageManager();
+        Context context = getUserContext(app, UserHandle.getUserHandleForUid(packageInfo.getUid()));
+
+        List<PermissionInfo> permissions = new ArrayList<>();
+        try {
+            permissions.addAll(getPermissionInfosForGroup(pm, permGroupName));
+        } catch (NameNotFoundException e) {
+            Log.e(LOG_TAG, "No permissions found for permission group " + permGroupName);
+            return false;
+        }
+
+        // Check in permission is already granted as we should not hide it in the UX at that point.
+        List<String> grantedPermissions = packageInfo.getGrantedPermissions();
+        for (PermissionInfo permission : permissions) {
+            boolean isCurrentlyGranted = grantedPermissions.contains(permission.name);
+            if (isCurrentlyGranted) {
+                Log.d(LOG_TAG, "At least one Health permission group permission is granted, "
+                        + "show permission group entry");
+                return true;
+            }
+        }
+
+        Intent viewUsageIntent = new Intent(Intent.ACTION_VIEW_PERMISSION_USAGE);
+        viewUsageIntent.addCategory(HealthConnectManager.CATEGORY_HEALTH_PERMISSIONS);
+        viewUsageIntent.setPackage(packageInfo.getPackageName());
+
+        ResolveInfo resolveInfo = pm.resolveActivity(viewUsageIntent, PackageManager.MATCH_ALL);
+        if (resolveInfo == null) {
+            Log.e(LOG_TAG, "Package that asks for Health permission must also handle "
+                    + "VIEW_PERMISSION_USAGE_INTENT.");
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/PermissionController/tests/permissionui/Android.bp
+++ b/PermissionController/tests/permissionui/Android.bp
@@ -60,6 +60,8 @@ android_test {
         ":CtsAppThatRequestsLocationPermission29",
         ":PermissionUiUseStoragePermissionApp",
         ":PermissionUiUseCameraPermissionApp",
+        ":PermissionUiUseHealthConnectPermissionApp",
+        ":PermissionUiInvalidUseHealthConnectPermissionApp",
         ":PermissionUiDefineAdditionalPermissionApp",
         ":PermissionUiUseAdditionalPermissionApp",
         ":PermissionUiUseTwoAdditionalPermissionsApp",

--- a/PermissionController/tests/permissionui/AndroidTest.xml
+++ b/PermissionController/tests/permissionui/AndroidTest.xml
@@ -43,6 +43,10 @@
                 value="/data/local/tmp/permissioncontroller/tests/permissionui/PermissionUiUseStoragePermissionApp.apk" />
         <option name="push-file" key="PermissionUiUseCameraPermissionApp.apk"
                 value="/data/local/tmp/permissioncontroller/tests/permissionui/PermissionUiUseCameraPermissionApp.apk" />
+        <option name="push-file" key="PermissionUiUseHealthConnectPermissionApp.apk"
+            value="/data/local/tmp/permissioncontroller/tests/permissionui/PermissionUiUseHealthConnectPermissionApp.apk" />
+        <option name="push-file" key="PermissionUiInvalidUseHealthConnectPermissionApp.apk"
+            value="/data/local/tmp/permissioncontroller/tests/permissionui/PermissionUiInvalidUseHealthConnectPermissionApp.apk" />
         <option name="push-file" key="PermissionUiDefineAdditionalPermissionApp.apk"
                 value="/data/local/tmp/permissioncontroller/tests/permissionui/PermissionUiDefineAdditionalPermissionApp.apk" />
         <option name="push-file" key="PermissionUiUseAdditionalPermissionApp.apk"

--- a/PermissionController/tests/permissionui/PermissionUiInvalidUseHealthConnectPermissionApp/Android.bp
+++ b/PermissionController/tests/permissionui/PermissionUiInvalidUseHealthConnectPermissionApp/Android.bp
@@ -1,0 +1,34 @@
+//
+// Copyright (C) 2023 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package {
+    // See: http://go/android-license-faq
+    // A large-scale-change added 'default_applicable_licenses' to import
+    // all of the 'license_kinds' from "packages_modules_Permission_PermissionController_license"
+    // to get the below license kinds:
+    //   SPDX-license-identifier-Apache-2.0
+    default_applicable_licenses: [
+        "packages_modules_Permission_PermissionController_license",
+    ],
+}
+
+android_test_helper_app {
+    name: "PermissionUiInvalidUseHealthConnectPermissionApp",
+
+    srcs: ["src/**/*.kt"],
+
+    sdk_version: "34",
+}

--- a/PermissionController/tests/permissionui/PermissionUiInvalidUseHealthConnectPermissionApp/AndroidManifest.xml
+++ b/PermissionController/tests/permissionui/PermissionUiInvalidUseHealthConnectPermissionApp/AndroidManifest.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2020 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.permissioncontroller.tests.appthatrequestpermission">
+
+    <uses-permission android:name="android.permission.health.READ_FLOORS_CLIMBED" />
+    <uses-permission android:name="android.permission.health.READ_STEPS" />
+
+    <application android:label="HealthConnectRequestApp" />
+</manifest>
+

--- a/PermissionController/tests/permissionui/PermissionUiInvalidUseHealthConnectPermissionApp/src/com/android/permissioncontroller/tests/appthatrequestpermission/DummyActivity.kt
+++ b/PermissionController/tests/permissionui/PermissionUiInvalidUseHealthConnectPermissionApp/src/com/android/permissioncontroller/tests/appthatrequestpermission/DummyActivity.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.permissioncontroller.tests.appthatrequestpermission
+
+import android.app.Activity
+
+class DummyActivity : Activity()

--- a/PermissionController/tests/permissionui/PermissionUiUseHealthConnectPermissionApp/Android.bp
+++ b/PermissionController/tests/permissionui/PermissionUiUseHealthConnectPermissionApp/Android.bp
@@ -1,0 +1,34 @@
+//
+// Copyright (C) 2023 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package {
+    // See: http://go/android-license-faq
+    // A large-scale-change added 'default_applicable_licenses' to import
+    // all of the 'license_kinds' from "packages_modules_Permission_PermissionController_license"
+    // to get the below license kinds:
+    //   SPDX-license-identifier-Apache-2.0
+    default_applicable_licenses: [
+        "packages_modules_Permission_PermissionController_license",
+    ],
+}
+
+android_test_helper_app {
+    name: "PermissionUiUseHealthConnectPermissionApp",
+
+    srcs: ["src/**/*.kt"],
+
+    sdk_version: "34",
+}

--- a/PermissionController/tests/permissionui/PermissionUiUseHealthConnectPermissionApp/AndroidManifest.xml
+++ b/PermissionController/tests/permissionui/PermissionUiUseHealthConnectPermissionApp/AndroidManifest.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2020 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.permissioncontroller.tests.appthatrequestpermission">
+
+    <uses-permission android:name="android.permission.health.READ_FLOORS_CLIMBED" />
+    <uses-permission android:name="android.permission.health.READ_STEPS" />
+
+    <application android:label="HealthConnectRequestApp">
+        <activity android:name=".DummyActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW_PERMISSION_USAGE" />
+                <category android:name="android.intent.category.HEALTH_PERMISSIONS" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>
+

--- a/PermissionController/tests/permissionui/PermissionUiUseHealthConnectPermissionApp/src/com/android/permissioncontroller/tests/appthatrequestpermission/DummyActivity.kt
+++ b/PermissionController/tests/permissionui/PermissionUiUseHealthConnectPermissionApp/src/com/android/permissioncontroller/tests/appthatrequestpermission/DummyActivity.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.permissioncontroller.tests.appthatrequestpermission
+
+import android.app.Activity
+
+class DummyActivity : Activity()

--- a/PermissionController/tests/permissionui/src/com/android/permissioncontroller/permissionui/ui/HealthConnectAllAppPermissionFragmentTest.kt
+++ b/PermissionController/tests/permissionui/src/com/android/permissioncontroller/permissionui/ui/HealthConnectAllAppPermissionFragmentTest.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.permissioncontroller.permissionui.ui
+
+import android.content.Intent
+import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SdkSuppress
+import androidx.test.uiautomator.By
+import com.android.compatibility.common.util.SystemUtil.eventually
+import com.android.compatibility.common.util.SystemUtil.runWithShellPermissionIdentity
+import com.android.compatibility.common.util.UiAutomatorUtils2.waitFindObject
+import com.android.compatibility.common.util.UiAutomatorUtils2.waitFindObjectOrNull
+import com.android.permissioncontroller.permissionui.wakeUpScreen
+import org.junit.After
+import org.junit.Assert.assertNull
+import org.junit.Assume.assumeFalse
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Simple tests for {@link AllAppPermissionsFragment} for Health Connect behaviors
+ * Currently, does NOT run on TV.
+ * TODO(b/178576541): Adapt and run on TV.
+ * Run with:
+ * atest HealthConnectAllAppPermissionFragmentTest
+ */
+@RunWith(AndroidJUnit4::class)
+@SdkSuppress(minSdkVersion = Build.VERSION_CODES.UPSIDE_DOWN_CAKE, codeName = "UpsideDownCake")
+class HealthConnectAllAppPermissionFragmentTest : BasePermissionUiTest() {
+    @Before
+    fun assumeNotTelevision() = assumeFalse(isTelevision)
+
+    @Before
+    fun wakeScreenUp() {
+        wakeUpScreen()
+    }
+
+    @After
+    fun uninstallTestApp() {
+        uninstallTestApps()
+    }
+    @Test
+    fun usedHealthConnectPermissionsAreListed() {
+        installTestAppThatUsesHealthConnectPermission()
+
+        startManageAppPermissionsActivity()
+
+        eventually {
+            waitFindObject(By.text(HEALTH_CONNECT_LABEL))
+            waitFindObject(By.text(HEALTH_CONNECT_PERMISSION_READ_FLOORS_CLIMBED_LABEL))
+            waitFindObject(By.text(HEALTH_CONNECT_PERMISSION_READ_STEPS_LABEL))
+        }
+    }
+
+    @Test
+    fun invalidUngrantedUsedHealthConnectPermissionsAreNotListed() {
+        installInvalidTestAppThatUsesHealthConnectPermission()
+
+        startManageAppPermissionsActivity()
+
+        eventually {
+            assertNull(waitFindObjectOrNull(By.text(HEALTH_CONNECT_LABEL), TIMEOUT_SHORT))
+            assertNull(waitFindObjectOrNull(
+                By.text(HEALTH_CONNECT_PERMISSION_READ_FLOORS_CLIMBED_LABEL), TIMEOUT_SHORT))
+            assertNull(waitFindObjectOrNull(
+                By.text(HEALTH_CONNECT_PERMISSION_READ_STEPS_LABEL), TIMEOUT_SHORT))
+        }
+    }
+
+    @Test
+    fun invalidGrantedUsedHealthConnectPermissionsAreListed() {
+        installInvalidTestAppThatUsesHealthConnectPermission()
+        grantTestAppPermission(HEALTH_CONNECT_PERMISSION_READ_FLOORS_CLIMBED)
+
+        startManageAppPermissionsActivity()
+
+        // Ensure that Health Connect permission group permissions are present if a single one is
+        // already granted, regardless of whether the intent filters are incorrectly or not setup
+        // for the app
+        eventually {
+            waitFindObject(By.text(HEALTH_CONNECT_LABEL))
+            waitFindObject(By.text(HEALTH_CONNECT_PERMISSION_READ_FLOORS_CLIMBED_LABEL))
+
+            // READ_STEPS is not granted, but should still be present due to READ_FLOORS_CLIMBED
+            // being granted
+            waitFindObject(By.text(HEALTH_CONNECT_PERMISSION_READ_STEPS_LABEL))
+        }
+    }
+
+    private fun startManageAppPermissionsActivity() {
+        runWithShellPermissionIdentity {
+            instrumentationContext.startActivity(Intent(Intent.ACTION_MANAGE_APP_PERMISSIONS)
+                .apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                    putExtra(Intent.EXTRA_PACKAGE_NAME, PERM_USER_PACKAGE)
+                })
+        }
+
+        waitFindObject(By.descContains(MORE_OPTIONS)).click()
+        waitFindObject(By.text(ALL_PERMISSIONS)).click()
+    }
+
+    companion object {
+        // Health connect label uses a non breaking space
+        private const val HEALTH_CONNECT_LABEL = "Health\u00A0Connect"
+        private const val HEALTH_CONNECT_PERMISSION_READ_FLOORS_CLIMBED =
+            "android.permission.health.READ_FLOORS_CLIMBED"
+        private const val HEALTH_CONNECT_PERMISSION_READ_FLOORS_CLIMBED_LABEL =
+            "Read floors climbed"
+        private const val HEALTH_CONNECT_PERMISSION_READ_STEPS_LABEL =
+            "Read steps"
+
+        private const val MORE_OPTIONS = "More options"
+        private const val ALL_PERMISSIONS = "All permissions"
+
+        private val TIMEOUT_SHORT = 500L
+    }
+}

--- a/PermissionController/tests/permissionui/src/com/android/permissioncontroller/permissionui/ui/HealthConnectAppPermissionFragmentTest.kt
+++ b/PermissionController/tests/permissionui/src/com/android/permissioncontroller/permissionui/ui/HealthConnectAppPermissionFragmentTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.permissioncontroller.permissionui.ui
+
+import android.content.Intent
+import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SdkSuppress
+import androidx.test.uiautomator.By
+import com.android.compatibility.common.util.SystemUtil.eventually
+import com.android.compatibility.common.util.SystemUtil.runWithShellPermissionIdentity
+import com.android.compatibility.common.util.UiAutomatorUtils2.waitFindObject
+import com.android.compatibility.common.util.UiAutomatorUtils2.waitFindObjectOrNull
+import com.android.permissioncontroller.permissionui.wakeUpScreen
+import org.junit.After
+import org.junit.Assert.assertNull
+import org.junit.Assume.assumeFalse
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Simple tests for {@link AppPermissionsFragment} for Health Connect behaviors
+ * Currently, does NOT run on TV.
+ * TODO(b/178576541): Adapt and run on TV.
+ * Run with:
+ * atest HealthConnectAppPermissionFragmentTest
+ */
+@RunWith(AndroidJUnit4::class)
+@SdkSuppress(minSdkVersion = Build.VERSION_CODES.UPSIDE_DOWN_CAKE, codeName = "UpsideDownCake")
+class HealthConnectAppPermissionFragmentTest : BasePermissionUiTest() {
+    @Before
+    fun assumeNotTelevision() = assumeFalse(isTelevision)
+
+    @Before
+    fun wakeScreenUp() {
+        wakeUpScreen()
+    }
+
+    @After
+    fun uninstallTestApp() {
+        uninstallTestApps()
+    }
+    @Test
+    fun usedHealthConnectPermissionsAreListed() {
+        installTestAppThatUsesHealthConnectPermission()
+
+        startManageAppPermissionsActivity()
+
+        eventually {
+            waitFindObject(By.text(HEALTH_CONNECT_LABEL))
+        }
+    }
+
+    @Test
+    fun invalidUngrantedUsedHealthConnectPermissionsAreNotListed() {
+        installInvalidTestAppThatUsesHealthConnectPermission()
+
+        startManageAppPermissionsActivity()
+
+        // TODO(b/288286032): update to use waitUntilObjectGone
+        eventually {
+            assertNull(waitFindObjectOrNull(By.text(HEALTH_CONNECT_LABEL), TIMEOUT_SHORT))
+        }
+    }
+
+    @Test
+    fun invalidGrantedUsedHealthConnectPermissionsAreListed() {
+        installInvalidTestAppThatUsesHealthConnectPermission()
+        grantTestAppPermission(HEALTH_CONNECT_PERMISSION_READ_FLOORS_CLIMBED)
+
+        startManageAppPermissionsActivity()
+
+        eventually {
+            waitFindObject(By.text(HEALTH_CONNECT_LABEL))
+        }
+    }
+
+    private fun startManageAppPermissionsActivity() {
+        runWithShellPermissionIdentity {
+            instrumentationContext.startActivity(Intent(Intent.ACTION_MANAGE_APP_PERMISSIONS)
+                .apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                    putExtra(Intent.EXTRA_PACKAGE_NAME, PERM_USER_PACKAGE)
+                })
+        }
+    }
+
+    companion object {
+        // Health connect label uses a non breaking space
+        private const val HEALTH_CONNECT_LABEL = "Health\u00A0Connect"
+        private const val HEALTH_CONNECT_PERMISSION_READ_FLOORS_CLIMBED =
+            "android.permission.health.READ_FLOORS_CLIMBED"
+
+        private val TIMEOUT_SHORT = 500L
+    }
+}

--- a/PermissionController/tests/permissionui/src/com/android/permissioncontroller/permissionui/ui/TestAppUtils.kt
+++ b/PermissionController/tests/permissionui/src/com/android/permissioncontroller/permissionui/ui/TestAppUtils.kt
@@ -24,6 +24,10 @@ import android.permission.cts.PermissionUtils.uninstallApp
 private const val APK_DIRECTORY = "/data/local/tmp/permissioncontroller/tests/permissionui/"
 private const val LOCATION_PERM_USER_APK = "$APK_DIRECTORY/AppThatRequestsLocation.apk"
 private const val CAMERA_PERM_USER_APK = "$APK_DIRECTORY/PermissionUiUseCameraPermissionApp.apk"
+private const val HEALTH_CONNECT_PERMISSION_USER_APK =
+    "$APK_DIRECTORY/PermissionUiUseHealthConnectPermissionApp.apk"
+private const val INVALID_HEALTH_CONNECT_PERMISSION_USER_APK =
+    "$APK_DIRECTORY/PermissionUiInvalidUseHealthConnectPermissionApp.apk"
 private const val ADDITIONAL_PERM_USER_APK =
     "$APK_DIRECTORY/PermissionUiUseAdditionalPermissionApp.apk"
 private const val TWO_ADDITIONAL_PERM_USER_APK =
@@ -32,10 +36,10 @@ private const val ADDITIONAL_PERM_DEFINER_APK =
     "$APK_DIRECTORY/PermissionUiDefineAdditionalPermissionApp.apk"
 
 // All 4 of the AppThatUses_X_Permission(s) applications share the same package name.
-private const val PERM_USER_PACKAGE =
-    "com.android.permissioncontroller.tests.appthatrequestpermission"
 private const val PERM_DEFINER_PACKAGE =
     "com.android.permissioncontroller.tests.appthatdefinespermission"
+const val PERM_USER_PACKAGE =
+    "com.android.permissioncontroller.tests.appthatrequestpermission"
 
 const val CAMERA_TEST_APP_LABEL = "CameraRequestApp"
 
@@ -49,6 +53,9 @@ const val TEST_APP_DEFINED_PERMISSION_C_LABEL = "Permission C"
 
 fun installTestAppThatRequestsLocation() = install(LOCATION_PERM_USER_APK)
 fun installTestAppThatUsesCameraPermission() = install(CAMERA_PERM_USER_APK)
+fun installTestAppThatUsesHealthConnectPermission() = install(HEALTH_CONNECT_PERMISSION_USER_APK)
+fun installInvalidTestAppThatUsesHealthConnectPermission() =
+    install(INVALID_HEALTH_CONNECT_PERMISSION_USER_APK)
 fun installTestAppThatUsesAdditionalPermission() = install(ADDITIONAL_PERM_USER_APK)
 fun installTestAppThatUsesTwoAdditionalPermissions() = install(TWO_ADDITIONAL_PERM_USER_APK)
 fun installTestAppThatDefinesAdditionalPermissions() = install(ADDITIONAL_PERM_DEFINER_APK)


### PR DESCRIPTION
From AOSP:

Don't show Health Permissions if the app doesn't handle VIEW_PERMISSION_USAGE

Relnote: Filter invalid health permission usage apps BUG:273946678
Test: atest HealthConnectAppPermissionFragmentTest Test: atest HealthConnectAllAppPermissionFragmentTest Change-Id: I6892177329471591ee3cfb67ce570453e6baf231