### PR TITLE
fix missing Storage/Contact Scopes link after going back to perm screen

### DIFF
--- a/PermissionController/src/com/android/permissioncontroller/permission/ui/handheld/AppPermissionFragment.java
+++ b/PermissionController/src/com/android/permissioncontroller/permission/ui/handheld/AppPermissionFragment.java
@@ -266,6 +266,7 @@ public class AppPermissionFragment extends SettingsWithLargeHeader
         mAskOneTimeButton = root.requireViewById(R.id.ask_one_time_radio_button);
         mAskButton = root.requireViewById(R.id.ask_radio_button);
         mSelectPhotosButton = root.requireViewById(R.id.select_radio_button);
+        mExtraViews = root.requireViewById(R.id.layout_app_permission_extra_views);
         mDenyButton = root.requireViewById(R.id.deny_radio_button);
         mDenyForegroundButton = root.requireViewById(R.id.deny_foreground_radio_button);
 
@@ -747,12 +748,9 @@ public class AppPermissionFragment extends SettingsWithLargeHeader
 
     private CharSequence mOrigDenyButtonText;
 
-    private void setupExtraViews() {
-        View rootView = getView();
-        if (rootView == null) {
-            return;
-        }
+    private ViewGroup mExtraViews;
 
+    private void setupExtraViews() {
         if (!mDenyButton.isEnabled()) {
             return;
         }
@@ -782,13 +780,11 @@ public class AppPermissionFragment extends SettingsWithLargeHeader
             }
         }
 
-        ViewGroup layout = rootView.requireViewById(R.id.layout_app_permission_extra_views);
-
-        TextView view = layout.requireViewById(R.id.app_permission_extra_link_1);
+        TextView view = mExtraViews.requireViewById(R.id.app_permission_extra_link_1);
 
         view.setText(link.getSettingsLinkText(ctx, packageName, packageState));
         view.setOnClickListener(v -> link.onSettingsLinkClick(this, packageName, packageState));
 
-        layout.setVisibility(View.VISIBLE);
+        mExtraViews.setVisibility(View.VISIBLE);
     }
 }


### PR DESCRIPTION
14 QPR2 port introduced a UI regression: Storage/Contact Scopes link on app permission screen disappeared after opening Storage/Contact Scopes config screen, then going back to app permission screen. Re-opening app permission screen made the link visible again.