### PR TITLE
fix UI state being lost in some cases after activity configuration change for Storage/Contact Scopes UIs

### DIFF
--- a/PermissionController/src/com/android/permissioncontroller/cscopes/ContactScopesFragment.kt
+++ b/PermissionController/src/com/android/permissioncontroller/cscopes/ContactScopesFragment.kt
@@ -92,6 +92,8 @@ class ContactScopesFragment : PackageExtraConfigFragment(), MenuProvider {
         footer = createFooterPreference()
 
         requireActivity().addMenuProvider(this, this)
+
+        update()
     }
 
     private fun createScopeTypeCategory(type: Int, label: Int): PreferenceCategory {

--- a/PermissionController/src/com/android/permissioncontroller/ext/BasePreferenceFragmentCompat.kt
+++ b/PermissionController/src/com/android/permissioncontroller/ext/BasePreferenceFragmentCompat.kt
@@ -21,9 +21,17 @@ abstract class BasePreferenceFragmentCompat : PreferenceFragmentCompat() {
         preferenceScreen = preferenceManager.createPreferenceScreen(context_)
     }
 
+    private var callUpdateOnResume = false
+
     override fun onResume() {
         super.onResume()
-        update()
+        if (callUpdateOnResume) {
+            update()
+        } else {
+            // update() has to be called by subclasses from onCreate() to avoid state loss after
+            // configuration change. onCreate() is called right before the first onResume()
+            callUpdateOnResume = true
+        }
     }
 
     override fun onStart() {

--- a/PermissionController/src/com/android/permissioncontroller/ext/BaseSettingsWithLargeHeaderFragment.kt
+++ b/PermissionController/src/com/android/permissioncontroller/ext/BaseSettingsWithLargeHeaderFragment.kt
@@ -32,9 +32,17 @@ abstract class BaseSettingsWithLargeHeaderFragment : SettingsWithLargeHeader() {
         return super.onOptionsItemSelected(item)
     }
 
+    private var callUpdateOnResume = false
+
     override fun onResume() {
         super.onResume()
-        update()
+        if (callUpdateOnResume) {
+            update()
+        } else {
+            // update() has to be called by subclasses from onCreate() to avoid state loss after
+            // configuration change. onCreate() is called right before the first onResume()
+            callUpdateOnResume = true
+        }
     }
 
     override fun onStart() {

--- a/PermissionController/src/com/android/permissioncontroller/sscopes/StorageScopesFragment.java
+++ b/PermissionController/src/com/android/permissioncontroller/sscopes/StorageScopesFragment.java
@@ -118,6 +118,8 @@ public final class StorageScopesFragment extends PackageExtraConfigFragment {
         categoryFiles = createCategory(this, R.string.sscopes_files);
 
         footer = createFooterPreference(this);
+
+        update();
     }
 
     public void update() {


### PR DESCRIPTION
This bug didn't affect Storage/Contact Scopes fragment instances that were launched by going to App info -> Permissions -> `<permission>` -> Storage/Contact Scopes due to `android:configChanges="orientation|keyboardHidden|screenSize"` manifest declaration for the upstream ManagePermissionsActivity.