### PR TITLE
don't hide Exploit protection Safety Center item in non-primary users

### DIFF
--- a/SafetyCenter/Resources/res/raw-v34/safety_center_config.xml
+++ b/SafetyCenter/Resources/res/raw-v34/safety_center_config.xml
@@ -121,7 +121,6 @@
 
             <static-safety-source
                 id="AndroidExploitProtectionSettings"
-                user="primary"
                 profile="primary_profile_only"
                 intentAction="com.android.settings.EXPLOIT_PROTECTION_SETTINGS"
                 title="@com.android.safetycenter.resources:string/exploit_protection_title"

--- a/SafetyCenter/Resources/res/raw-v35/safety_center_config.xml
+++ b/SafetyCenter/Resources/res/raw-v35/safety_center_config.xml
@@ -133,7 +133,6 @@
 
             <static-safety-source
                 id="AndroidExploitProtectionSettings"
-                user="primary"
                 profile="primary_profile_only"
                 intentAction="com.android.settings.EXPLOIT_PROTECTION_SETTINGS"
                 title="@com.android.safetycenter.resources:string/exploit_protection_title"


### PR DESCRIPTION
App exploit protection items now link screens that show the state of the given exploit protection feature across all apps of the current user.