### PR TITLE
fix a Contact Scopes UI bug

### DIFF
--- a/PermissionController/src/com/android/permissioncontroller/permission/ui/handheld/max35/LegacyAppPermissionFragment.java
+++ b/PermissionController/src/com/android/permissioncontroller/permission/ui/handheld/max35/LegacyAppPermissionFragment.java
@@ -500,26 +500,19 @@ public class LegacyAppPermissionFragment extends SettingsWithLargeHeader
         }
 
         setupExtraViews();
-
-        {
-            Context ctx = requireContext();
-            var epl = ExtraPermissionLinkKt.getExtraPermissionLink(ctx, mPackageName, mPermGroupName);
-            if (epl != null && epl.isAllowPermissionSettingsButtonBlocked(ctx, mPackageName)) {
-                mAllowButton.setOnTouchListener((v, ev) -> {
-                    if (ev.getAction() == MotionEvent.ACTION_UP) {
-                        epl.onAllowPermissionSettingsButtonClick(ctx, mPackageName);
-                    }
-                    return true;
-                });
-                return;
-            }
-        }
     }
 
     private void allowButtonFrameClickListener() {
         if (!mAllowButton.isEnabled()) {
             mViewModel.handleDisabledAllowButton(this);
         } else {
+            Context ctx = requireContext();
+            var epl = ExtraPermissionLinkKt.getExtraPermissionLink(ctx, mPackageName, mPermGroupName);
+            if (epl != null && epl.isAllowPermissionSettingsButtonBlocked(ctx, mPackageName)) {
+                epl.onAllowPermissionSettingsButtonClick(ctx, mPackageName);
+                return;
+            }
+
             markSingleButtonAsChecked(ButtonType.ALLOW);
             mViewModel.requestChange(false, this, this, ChangeRequest.GRANT_FOREGROUND,
                     APP_PERMISSION_FRAGMENT_ACTION_REPORTED__BUTTON_PRESSED__ALLOW);


### PR DESCRIPTION
Fix a Contact Scopes UI bug that allowed to select the "Allow" option in Contacts permission screen when Contact Scopes was enabled, which didn't actually allow the Contacts permission.