### PR TITLE
fixup! enable usage timeline for all permission groups

### DIFF
--- a/PermissionController/src/com/android/permissioncontroller/permission/domain/usecase/v31/GetPermissionGroupUsageDetailsUseCase.kt
+++ b/PermissionController/src/com/android/permissioncontroller/permission/domain/usecase/v31/GetPermissionGroupUsageDetailsUseCase.kt
@@ -28,6 +28,7 @@ import com.android.permissioncontroller.appops.data.repository.v31.AppOpReposito
 import com.android.permissioncontroller.permission.data.repository.v31.PermissionRepository
 import com.android.permissioncontroller.permission.domain.model.v31.PermissionTimelineUsageModel
 import com.android.permissioncontroller.permission.domain.model.v31.PermissionTimelineUsageModelWrapper
+import com.android.permissioncontroller.permission.ui.model.v31.PermissionUsageControlPreferenceUtils
 import com.android.permissioncontroller.permission.ui.model.v31.PermissionUsageDetailsViewModel.Companion.CLUSTER_SPACING_MINUTES
 import com.android.permissioncontroller.permission.ui.model.v31.PermissionUsageDetailsViewModel.Companion.ONE_MINUTE_MS
 import com.android.permissioncontroller.permission.utils.LocationUtils
@@ -301,12 +302,7 @@ class GetPermissionGroupUsageDetailsUseCase(
 
         private fun permissionGroupToOpNamesMap(): Map<String, List<String>> {
             val permissionGroupOpNamesMap = mutableMapOf<String, MutableList<String>>()
-            val permissionGroups =
-                listOf(
-                    Manifest.permission_group.CAMERA,
-                    Manifest.permission_group.LOCATION,
-                    Manifest.permission_group.MICROPHONE,
-                )
+            val permissionGroups = PermissionUsageControlPreferenceUtils.SENSOR_DATA_PERMISSIONS
             permissionGroups.forEach { permissionGroup ->
                 val opNames =
                     PermissionMapping.getPlatformPermissionNamesOfGroup(permissionGroup)


### PR DESCRIPTION
Makes it ready for `PermissionUsageDetailsViewModelV2`, which is guarded by an aconfig flag (currently off).

Flag: com.android.permission.flags.livedata_refactor_permission_timeline_enabled
Test: Enabling the flag, opening the Permission timeline for photos and videos, phone, contacts, nearby devices, SMS (not related to `Manifest.permission_group.LOCATION`, `Manifest.permission_group.CAMERA`, `Manifest.permission_group.MICROPHONE`). 

If the flag is enabled and this change is not applied, an exception occurs here when trying to open up a specific permission history that is not one of `Manifest.permission_group.LOCATION`, `Manifest.permission_group.CAMERA`, `Manifest.permission_group.MICROPHONE`:

https://github.com/GrapheneOS/platform_packages_modules_Permission/blob/e1c4506b2a183212c494bc861751ad48066207e8/PermissionController/src/com/android/permissioncontroller/permission/domain/usecase/v31/GetPermissionGroupUsageDetailsUseCase.kt#L58
