### PR TITLE
Tint the allow button's gray in the runtime permission dialog while they are deactivated 

### DIFF
--- a/PermissionController/src/com/android/permissioncontroller/permission/ui/handheld/GrantPermissionsViewHandlerImpl.kt
+++ b/PermissionController/src/com/android/permissioncontroller/permission/ui/handheld/GrantPermissionsViewHandlerImpl.kt
@@ -352,6 +352,7 @@ class GrantPermissionsViewHandlerImpl(
 
             if (buttonVisible && GrantPermissionsActivity.isAllowButton(pos)) {
                 button.isEnabled = false
+                button.setAlpha(0.5f)
 
                 val shouldLog = Log.isLoggable(TAG, Log.DEBUG)
                 val suffix = "$pos, pkg $mAppPackageName, group $groupName"
@@ -359,6 +360,7 @@ class GrantPermissionsViewHandlerImpl(
 
                 val action = Runnable {
                     button.isEnabled = true
+                    button.setAlpha(1f)
                     if (shouldLog) Log.d(TAG, "enabled button $suffix")
                 }
                 button.postDelayed(action, 1000)


### PR DESCRIPTION
Grays out the allow buttons  in the runtime permission dialog when they are delayed. This way the user won't try to tap it and then be confused.

<img width="902" height="757" alt="Screenshot_1756843184" src="https://github.com/user-attachments/assets/28f36909-c39d-4754-b6a1-8895dc1b0246" /> 

Closes: https://github.com/GrapheneOS/os-issue-tracker/issues/6054