### PR TITLE
Add toggle to hide location access indicator on a per-app basis

### DIFF
--- a/PermissionController/AndroidManifest.xml
+++ b/PermissionController/AndroidManifest.xml
@@ -735,6 +735,12 @@
             android:permission="android.permission.WRITE_SECURE_SETTINGS"
             android:exported="true" />
 
+        <activity
+            android:name="com.android.permissioncontroller.privacy.LocationIndicatorActivity"
+            android:theme="@style/Theme.PermissionController.Settings.FilterTouches"
+            android:permission="android.permission.WRITE_SECURE_SETTINGS"
+            android:exported="true" />
+
         <service
             android:name="com.android.permissioncontroller.permission.service.DeviceStateAppFunctionService"
             android:permission="android.permission.BIND_APP_FUNCTION_SERVICE"

--- a/PermissionController/res/navigation/nav_graph.xml
+++ b/PermissionController/res/navigation/nav_graph.xml
@@ -202,4 +202,9 @@
         android:name="com.android.permissioncontroller.cscopes.ContactScopesWrapperFragment"
         android:label="ContactScopes"/>
 
+    <fragment
+        android:id="@+id/location_indicator"
+        android:name="com.android.permissioncontroller.privacy.LocationIndicatorWrapperFragment"
+        android:label="LocationIndicator"/>
+
 </navigation>

--- a/PermissionController/res/values/strings_ext.xml
+++ b/PermissionController/res/values/strings_ext.xml
@@ -3,4 +3,9 @@
     <string name="scopes_list_is_full">Scope list is full</string>
     <string name="scopes_menu_item_turn_off">Turn off</string>
     <string name="scopes_btn_remove_scope">Remove</string>
+
+    <string name="location_indicator">Location indicator</string>
+    <string name="location_indicator_footer">When enabled, the standard privacy indicator will not show when the app is using location. It is assumed that the app will always be tracking your location. Location usage will still be logged.</string>
+    <string name="hide_location_indicator_title">Hide location indicator</string>
+    <string name="hide_location_indicator_toast">Changes will take effect the next time the app requests location access.</string>
 </resources>

--- a/PermissionController/src/com/android/permissioncontroller/permission/ui/GrantPermissionsActivity.java
+++ b/PermissionController/src/com/android/permissioncontroller/permission/ui/GrantPermissionsActivity.java
@@ -1046,6 +1046,7 @@ public class GrantPermissionsActivity extends SettingsActivity
 
     public static final int REQ_CODE_SETUP_STORAGE_SCOPES = 100;
     public static final int REQ_CODE_SETUP_CONTACT_SCOPES = 101;
+    public static final int REQ_CODE_SETUP_LOCATION_INDICATOR = 102;
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
@@ -1068,6 +1069,11 @@ public class GrantPermissionsActivity extends SettingsActivity
             if (ContactScopesUtils.isContactScopesEnabled(mTargetPackage, getUser())) {
                 setResultAndFinish();
             }
+            return;
+        }
+
+        if (requestCode == REQ_CODE_SETUP_LOCATION_INDICATOR) {
+            setResultAndFinish();
             return;
         }
 

--- a/PermissionController/src/com/android/permissioncontroller/permission/ui/handheld/ExtraPermissionLink.kt
+++ b/PermissionController/src/com/android/permissioncontroller/permission/ui/handheld/ExtraPermissionLink.kt
@@ -6,6 +6,7 @@ import android.os.UserHandle
 import android.widget.Button
 import com.android.permissioncontroller.cscopes.ContactScopesLinks
 import com.android.permissioncontroller.permission.ui.GrantPermissionsActivity
+import com.android.permissioncontroller.privacy.LocationIndicatorLinks
 import com.android.permissioncontroller.sscopes.StorageScopesLinks
 
 abstract class ExtraPermissionLink {
@@ -29,6 +30,7 @@ abstract class ExtraPermissionLink {
 private val allExtraPermissionLinks = arrayOf(
         StorageScopesLinks,
         ContactScopesLinks,
+        LocationIndicatorLinks,
 )
 
 fun getExtraPermissionLink(ctx: Context, packageName: String, user: UserHandle, groupName: String): ExtraPermissionLink? {

--- a/PermissionController/src/com/android/permissioncontroller/privacy/LocationIndicatorActivity.kt
+++ b/PermissionController/src/com/android/permissioncontroller/privacy/LocationIndicatorActivity.kt
@@ -1,0 +1,8 @@
+package com.android.permissioncontroller.privacy
+
+import com.android.permissioncontroller.R
+import com.android.permissioncontroller.ext.PackageExtraConfigActivity
+
+class LocationIndicatorActivity : PackageExtraConfigActivity() {
+    override fun getNavGraphStart() = R.id.location_indicator
+}

--- a/PermissionController/src/com/android/permissioncontroller/privacy/LocationIndicatorFragment.kt
+++ b/PermissionController/src/com/android/permissioncontroller/privacy/LocationIndicatorFragment.kt
@@ -1,0 +1,62 @@
+package com.android.permissioncontroller.privacy
+
+import android.content.Intent
+import android.content.pm.GosPackageState
+import android.content.pm.GosPackageStateFlag
+import android.net.Uri
+import android.os.Bundle
+import android.widget.Toast
+import com.android.permissioncontroller.R
+import com.android.permissioncontroller.ext.PackageExtraConfigFragment
+import com.android.permissioncontroller.ext.addOrRemove
+import com.android.permissioncontroller.ext.createFooterPreference
+import com.android.settingslib.widget.FooterPreference
+import com.android.settingslib.widget.MainSwitchPreference
+
+class LocationIndicatorFragment : PackageExtraConfigFragment() {
+    lateinit var mainSwitch: MainSwitchPreference
+    lateinit var footer: FooterPreference
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        mainSwitch = MainSwitchPreference(context_).apply {
+            setTitle(R.string.hide_location_indicator_title)
+            setOnPreferenceChangeListener { _, newValue ->
+                val editor = GosPackageState.edit(pkgName, context_.user)
+                editor.setFlagState(
+                    GosPackageStateFlag.HIDE_LOCATION_INDICATOR,
+                    newValue as Boolean
+                )
+                val result = editor.apply()
+                if (result) {
+                    Toast.makeText(
+                        context_,
+                        R.string.hide_location_indicator_toast,
+                        Toast.LENGTH_LONG
+                    ).show()
+                }
+                result
+            }
+        }
+
+        footer = createFooterPreference()
+
+        update()
+    }
+
+    override fun getTitle(): CharSequence = getText(R.string.location_indicator)
+
+    override fun update() {
+        val state = getGosPackageState()
+        mainSwitch.isChecked = state.hasFlag(GosPackageStateFlag.HIDE_LOCATION_INDICATOR)
+        addOrRemove(mainSwitch, true)
+
+        footer.setSummary(R.string.location_indicator_footer)
+        footer.setLearnMoreAction {
+            val link = "https://grapheneos.org/features#location-data-access-indicator"
+            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(link)))
+        }
+        addOrRemove(footer, true)
+    }
+}

--- a/PermissionController/src/com/android/permissioncontroller/privacy/LocationIndicatorLinks.kt
+++ b/PermissionController/src/com/android/permissioncontroller/privacy/LocationIndicatorLinks.kt
@@ -1,0 +1,91 @@
+package com.android.permissioncontroller.privacy
+
+import android.Manifest
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ApplicationInfo
+import android.content.pm.GosPackageState
+import android.os.UserHandle
+import android.widget.Button
+import com.android.permissioncontroller.R
+import com.android.permissioncontroller.permission.ui.GrantPermissionsActivity
+import com.android.permissioncontroller.permission.ui.handheld.ExtraPermissionLink
+
+object LocationIndicatorLinks : ExtraPermissionLink() {
+
+    override fun isVisible(
+        ctx: Context,
+        groupName: String,
+        packageName: String,
+        user: UserHandle
+    ): Boolean {
+        // dont show on permission dialog requests or system apps
+        val inPermissionDialog = ctx is GrantPermissionsActivity
+        return groupName == Manifest.permission_group.LOCATION
+                && !inPermissionDialog
+                && !isSystemApp(ctx, user, packageName)
+    }
+
+    override fun setupDialogButton(button: Button) {
+        button.setText(R.string.location_indicator)
+    }
+
+    override fun onDialogButtonClick(activity: GrantPermissionsActivity, packageName: String) {
+        val intent = createConfigActivityIntent(packageName)
+        @Suppress("DEPRECATION")
+        activity.startActivityForResult(
+            intent,
+            GrantPermissionsActivity.REQ_CODE_SETUP_LOCATION_INDICATOR
+        )
+    }
+
+    override fun isAllowPermissionSettingsButtonBlocked(
+        ctx: Context, packageName: String,
+        user: UserHandle
+    ): Boolean {
+        return false
+    }
+
+    override fun onAllowPermissionSettingsButtonClick(ctx: Context) {
+    }
+
+    override fun getSettingsDeniedRadioButtonSuffix(
+        ctx: Context,
+        packageState: GosPackageState
+    ): String? {
+        return null
+    }
+
+    override fun getSettingsLinkText(ctx: Context): CharSequence {
+        return ctx.getText(R.string.location_indicator)
+    }
+
+    override fun onSettingsLinkClick(ctx: Context, packageName: String, user: UserHandle) {
+        val intent = createConfigActivityIntent(packageName)
+        ctx.startActivityAsUser(intent, user)
+    }
+
+    fun createConfigActivityIntent(targetPkg: String): Intent {
+        val i = Intent()
+        val pkg = "com.android.permissioncontroller"
+        i.setComponent(ComponentName.createRelative(pkg, ".privacy.LocationIndicatorActivity"))
+        i.putExtra(Intent.EXTRA_PACKAGE_NAME, targetPkg)
+        return i
+    }
+
+    fun isSystemApp(ctx: Context, userHandle: UserHandle, packageName: String): Boolean {
+        return try {
+            val appInfo = ctx.packageManager.getApplicationInfoAsUser(
+                packageName,
+                0,
+                userHandle
+            )
+            (appInfo.flags and ApplicationInfo.FLAG_SYSTEM) != 0 ||
+                    (appInfo.flags and ApplicationInfo.FLAG_UPDATED_SYSTEM_APP) != 0
+        } catch (_: Exception) {
+            false
+        }
+    }
+}
+

--- a/PermissionController/src/com/android/permissioncontroller/privacy/LocationIndicatorWrapperFragment.kt
+++ b/PermissionController/src/com/android/permissioncontroller/privacy/LocationIndicatorWrapperFragment.kt
@@ -1,0 +1,8 @@
+package com.android.permissioncontroller.privacy
+
+import androidx.preference.PreferenceFragmentCompat
+import com.android.permissioncontroller.permission.ui.handheld.PermissionsCollapsingToolbarBaseFragment
+
+class LocationIndicatorWrapperFragment : PermissionsCollapsingToolbarBaseFragment() {
+    override fun createPreferenceFragment(): PreferenceFragmentCompat = LocationIndicatorFragment()
+}


### PR DESCRIPTION
Adds ExtraPermissionLink in PermissionController which allows the user to toggle the HIDE_LOCATION_INDICATOR flag for specific apps. This reuses much of the code used by Contact/Storage scopes.

This is useful for trusted apps such as Home Assistant or GPS logger which frequently collect and relay your location to a trusted destination. This feature improves both usability and privacy by reducing noise that users of these apps face and preventing them from "being used" to the privacy indicator when a _less_ trusted app uses it or disabling the feature entirely via an adb shell command.

<img width="356" height="638" alt="image" src="https://github.com/user-attachments/assets/bdbcbec5-ed17-42e3-be5d-6a8b85856f47" />

<img width="356" height="638" alt="image" src="https://github.com/user-attachments/assets/10a96ed2-72c5-49db-882d-d9605c1f2d93" />

Depends on change in platform_frameworks_base https://github.com/GrapheneOS/platform_frameworks_base/pull/305

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/1886