### PR TITLE
add option to allow Play services to access ICC auth

### DIFF
--- a/PermissionController/AndroidManifest.xml
+++ b/PermissionController/AndroidManifest.xml
@@ -745,6 +745,12 @@
             android:permission="com.android.permissioncontroller.permission.LAUNCH_GMSCOMPAT_ACTIVITIES"
             android:exported="true" />
 
+        <activity
+            android:name="com.android.permissioncontroller.ext.gmscore.GmsCoreConfigActivity"
+            android:theme="@style/Theme.PermissionController.Settings.Expressive.FilterTouches"
+            android:permission="com.android.permissioncontroller.permission.LAUNCH_GMSCOMPAT_ACTIVITIES"
+            android:exported="true" />
+
         <service
             android:name="com.android.permissioncontroller.permission.service.DeviceStateAppFunctionService"
             android:permission="android.permission.BIND_APP_FUNCTION_SERVICE"

--- a/PermissionController/res/navigation/nav_graph.xml
+++ b/PermissionController/res/navigation/nav_graph.xml
@@ -208,4 +208,9 @@
         android:name="com.android.permissioncontroller.ext.aauto.AndroidAutoConfigWrapperFragment"
         android:label="AndroidAutoConfig"/>
 
+    <fragment
+        android:id="@+id/gmscore_config"
+        android:name="com.android.permissioncontroller.ext.gmscore.GmsCoreConfigWrapperFragment"
+        android:label="GmsCoreConfig"/>
+
 </navigation>

--- a/PermissionController/res/values/strings_gms.xml
+++ b/PermissionController/res/values/strings_gms.xml
@@ -78,4 +78,18 @@ The network permission will also be allowed, it’s needed for communication wit
     <string name="speech_services_app">Speech Recognition &amp; Synthesis</string>
     <string name="google_search_app">Google app</string>
 
+    <string name="gmscore_settings">Play services permissions</string>
+    <string name="gmscore_settings_summary_disabled">Google Play services is disabled</string>
+    <string name="rcs_activation_category">RCS activation</string>
+    <string name="gmscore_icc_auth_perms_title">Allow ICC authentication with device identifiers</string>
+    <string name="gmscore_icc_auth_perms_confirm">
+"This permission allows Google Play services to:
+
+• Use your SIM (ICC-based authentication) and device identifiers to authenticate with your mobile carrier
+
+Google Play services should also be granted the Phone permission, and Google Messages should be granted the default SMS app role.
+
+Some carriers require an entitlement check (GSMA TS.43 with EAP-AKA authentication) to activate RCS in Google Messages. This permission allows Google Play services to use your SIM to complete the EAP-AKA challenge-response from the carrier's entitlement server.
+"
+</string>
 </resources>

--- a/PermissionController/src/com/android/permissioncontroller/ext/BaseGosPkgStateConfigFragment.kt
+++ b/PermissionController/src/com/android/permissioncontroller/ext/BaseGosPkgStateConfigFragment.kt
@@ -1,0 +1,202 @@
+package com.android.permissioncontroller.ext
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.ApplicationInfo
+import android.content.pm.GosPackageState
+import android.content.pm.PackageManager
+import android.os.Bundle
+import android.os.PatternMatcher
+import android.permission.PermissionManager
+import android.view.MenuItem
+import androidx.appcompat.app.AlertDialog
+import androidx.annotation.StringRes
+import androidx.preference.Preference
+import androidx.preference.PreferenceGroup
+import androidx.preference.PreferenceScreen
+import androidx.preference.SwitchPreferenceCompat
+import com.android.permissioncontroller.R
+import com.android.permissioncontroller.permission.ui.handheld.PermissionsFrameFragment
+import com.android.permissioncontroller.permission.ui.handheld.pressBack
+import getAppInfoOrNull
+
+/**
+ * Base fragment for specifying a configuration fragment for the given [packageName] with handling
+ * for [GosPackageState] preferences.
+ *
+ * Use [addPkgFlagPerm] to create a switch preference that will toggle a flag for a package flag in
+ * [GosPackageState]. These switch preferences are updated automatically and added to [pkgFlagPrefs]
+ *
+ * Use [packagePrefs] to preferences for packages that should be listening for
+ * package updates.
+ */
+abstract class BaseGosPkgStateConfigFragment(
+    protected val packageName: String,
+    @StringRes val titleStringRes: Int,
+) : PermissionsFrameFragment() {
+    protected val pkgFlagPrefs = mutableMapOf<Int, SwitchPreferenceCompat>()
+    /**
+     * A map of package names to Preferences for packages that should be updated when the
+     * corresponding package state changes
+     */
+    protected val packagePrefs = mutableMapOf<String, Preference>()
+
+    private val pkgChangeReceiver = object : BroadcastReceiver() {
+        override fun onReceive(ctx: Context, intent: Intent) {
+            updateUi()
+        }
+    }
+
+    protected lateinit var pkgManager: PackageManager
+
+    override fun onCreatePreferences(savedState: Bundle?, rootKey: String?) {
+        @Suppress("DEPRECATION") // see onOptionsItemSelected
+        setHasOptionsMenu(true)
+
+        val ctx = requireContext()
+        pkgManager = ctx.packageManager
+
+        val screen = preferenceManager.createPreferenceScreen(ctx)
+
+        configurePreferenceScreen(screen)
+
+        IntentFilter().run {
+            addAction(Intent.ACTION_PACKAGE_ADDED)
+            addAction(Intent.ACTION_PACKAGE_CHANGED)
+            addAction(Intent.ACTION_PACKAGE_REMOVED)
+            addDataScheme("package")
+            packagePrefs.keys.forEach {
+                addDataSchemeSpecificPart(it, PatternMatcher.PATTERN_LITERAL)
+            }
+            addDataSchemeSpecificPart(packageName, PatternMatcher.PATTERN_LITERAL)
+            ctx.registerReceiver(pkgChangeReceiver, this)
+        }
+
+        preferenceScreen = screen
+    }
+
+    /**
+     * Add the preferences to display here.
+     */
+    abstract fun configurePreferenceScreen(screen: PreferenceScreen)
+
+    override fun onDestroy() {
+        super.onDestroy()
+        requireContext().unregisterReceiver(pkgChangeReceiver)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        requireActivity().setTitle(titleStringRes)
+        updateUi()
+    }
+
+    protected fun addPkgFlagPerm(
+        dst: PreferenceGroup,
+        flag: Int,
+        @StringRes title: Int,
+        @StringRes confirmationText: Int,
+        @StringRes summary: Int = 0
+    ): SwitchPreferenceCompat {
+        val pref = SwitchPreferenceCompat(dst.context)
+        pref.setTitle(title)
+        if (summary != 0) {
+            pref.setSummary(summary)
+        }
+
+        pkgFlagPrefs[flag] = pref
+
+        pref.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, newValueB ->
+            val newValue = newValueB as Boolean
+
+            val ctx = requireContext()
+
+            if (newValue) {
+                AlertDialog.Builder(ctx).run {
+                    setMessage(getText(confirmationText))
+                    setPositiveButton(R.string.grant_dialog_button_allow) { _, _ ->
+                        updatePackageFlag(ctx, flag, true)
+                        updateUi()
+                    }
+                    setNegativeButton(R.string.cancel, null)
+                    show()
+                }
+                false
+            } else {
+                updatePackageFlag(ctx, flag, false)
+                true
+            }
+        }
+
+        dst.addPreference(pref)
+        return pref
+    }
+
+    private fun updatePackageFlag(ctx: Context, flag: Int, flagValue: Boolean) {
+        val userId = android.os.Process.myUserHandle().identifier
+        GosPackageState.edit(packageName, userId).run {
+            setPackageFlagState(flag, flagValue)
+            applyOrPressBack()
+        }
+
+        val permManager = ctx.getSystemService(PermissionManager::class.java)!!
+        permManager.updatePermissionState(packageName, userId)
+
+        GosPackageState.edit(packageName, userId).run {
+            killUidAfterApply()
+            applyOrPressBack()
+        }
+
+        val isPkgEnabled = pkgManager.getApplicationInfo(packageName, 0).enabled
+        if (isPkgEnabled) {
+            // this is needed to invalidate cached system_server state
+            pkgManager.setApplicationEnabledSetting(packageName, PackageManager.COMPONENT_ENABLED_STATE_DISABLED, userId)
+            pkgManager.setApplicationEnabledSetting(packageName, PackageManager.COMPONENT_ENABLED_STATE_ENABLED, userId)
+        }
+    }
+
+    /**
+     * Handle updating non-[GosPackageState] UI state here. GosPackageState preferences are already
+     * updated by the base class. The [applicationInfo] corresponds to [packageName].
+     */
+    abstract fun updateNonPkgStateUi(applicationInfo: ApplicationInfo)
+
+    private fun updateUi() {
+        val gmsCoreAppInfo = pkgManager.getAppInfoOrNull(packageName)
+
+        if (gmsCoreAppInfo == null) {
+            pressBack()
+            return
+        }
+
+        val ps = GosPackageState.get(packageName, requireContext().user)
+        pkgFlagPrefs.entries.forEach {
+            it.value.isChecked = ps.hasPackageFlag(it.key)
+        }
+
+        updateNonPkgStateUi(gmsCoreAppInfo)
+    }
+
+    protected fun GosPackageState.Editor.applyOrPressBack() {
+        if (apply()) {
+            updateUi()
+        } else {
+            // apply() fails only if the package is uninstalled
+            pressBack()
+        }
+    }
+
+    // it's not clear how to resolve deprecation warnings for setHasOptionsMenu and onOptionsItemSelected,
+    // they are suppressed in upstream fragments that use android.R.id.home too
+    @Suppress("DEPRECATION")
+    @Deprecated("Deprecated in Java")
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            pressBack()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
+    }
+}

--- a/PermissionController/src/com/android/permissioncontroller/ext/BaseGosPkgStateConfigFragment.kt
+++ b/PermissionController/src/com/android/permissioncontroller/ext/BaseGosPkgStateConfigFragment.kt
@@ -152,8 +152,8 @@ abstract class BaseGosPkgStateConfigFragment(
         val isPkgEnabled = pkgManager.getApplicationInfo(packageName, 0).enabled
         if (isPkgEnabled) {
             // this is needed to invalidate cached system_server state
-            pkgManager.setApplicationEnabledSetting(packageName, PackageManager.COMPONENT_ENABLED_STATE_DISABLED, userId)
-            pkgManager.setApplicationEnabledSetting(packageName, PackageManager.COMPONENT_ENABLED_STATE_ENABLED, userId)
+            pkgManager.setApplicationEnabledSetting(packageName, PackageManager.COMPONENT_ENABLED_STATE_DISABLED, 0)
+            pkgManager.setApplicationEnabledSetting(packageName, PackageManager.COMPONENT_ENABLED_STATE_ENABLED, 0)
         }
     }
 

--- a/PermissionController/src/com/android/permissioncontroller/ext/aauto/AndroidAutoConfig.kt
+++ b/PermissionController/src/com/android/permissioncontroller/ext/aauto/AndroidAutoConfig.kt
@@ -3,36 +3,26 @@ package com.android.permissioncontroller.ext.aauto
 import android.Manifest
 import android.app.compat.gms.AndroidAutoPackageFlag
 import android.app.compat.gms.GmsUtils
-import android.content.BroadcastReceiver
 import android.content.ComponentName
-import android.content.Context
 import android.content.Intent
-import android.content.IntentFilter
-import android.content.pm.GosPackageState
-import android.content.pm.GosPackageStateFlag
-import android.content.pm.PackageManager
+import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.content.pm.ServiceInfo
 import android.ext.PackageId
 import android.net.Uri
-import android.os.Bundle
-import android.os.PatternMatcher
-import android.permission.PermissionManager
 import android.provider.Settings
 import android.service.notification.NotificationListenerService
-import android.view.MenuItem
 import androidx.appcompat.app.AlertDialog
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceGroup
-import androidx.preference.SwitchPreferenceCompat
+import androidx.preference.PreferenceScreen
 import com.android.permissioncontroller.R
+import com.android.permissioncontroller.ext.BaseGosPkgStateConfigFragment
 import com.android.permissioncontroller.ext.BaseSettingsActivity
 import com.android.permissioncontroller.ext.addCategory
 import com.android.permissioncontroller.ext.addPref
 import com.android.permissioncontroller.permission.ui.handheld.PermissionsCollapsingToolbarBaseFragment
-import com.android.permissioncontroller.permission.ui.handheld.PermissionsFrameFragment
-import com.android.permissioncontroller.permission.ui.handheld.pressBack
 import getAppInfoOrNull
 
 class AndroidAutoConfigActivity : BaseSettingsActivity() {
@@ -43,36 +33,18 @@ class AndroidAutoConfigWrapperFragment : PermissionsCollapsingToolbarBaseFragmen
     override fun createPreferenceFragment(): PreferenceFragmentCompat = AndroidAutoConfigFragment()
 }
 
-private val PKG_NAME = PackageId.ANDROID_AUTO_NAME
-
-class AndroidAutoConfigFragment : PermissionsFrameFragment() {
+class AndroidAutoConfigFragment : BaseGosPkgStateConfigFragment(
+    packageName = PackageId.ANDROID_AUTO_NAME,
+    titleStringRes = R.string.android_auto
+) {
     lateinit var aautoSettingsPref: Preference
-    val pkgFlagPrefs = mutableMapOf<Int, SwitchPreferenceCompat>()
-    val packagePrefs = mutableMapOf<String, Preference>()
-
     lateinit var potentialIssues: PreferenceGroup
     lateinit var aautoVoiceCommandIssues: Preference
 
-    val pkgChangeReceiver = object : BroadcastReceiver() {
-        override fun onReceive(ctx: Context, intent: Intent) {
-            update()
-        }
-    }
-
-    lateinit var pkgManager: PackageManager
-
-    override fun onCreatePreferences(savedState: Bundle?, rootKey: String?) {
-        @Suppress("DEPRECATION") // see onOptionsItemSelected
-        setHasOptionsMenu(true)
-
-        val ctx = requireContext()
-        pkgManager = ctx.packageManager
-
-        val screen = preferenceManager.createPreferenceScreen(ctx)
-
+    override fun configurePreferenceScreen(screen: PreferenceScreen) {
         aautoSettingsPref = screen.addPref(getText(R.string.aauto_settings)).apply {
             intent = Intent(Intent.ACTION_APPLICATION_PREFERENCES).apply {
-                `package` = PKG_NAME
+                `package` = packageName
             }
         }
 
@@ -100,7 +72,7 @@ class AndroidAutoConfigFragment : PermissionsFrameFragment() {
 
             addPref(getText(R.string.aauto_app_info_title)).apply {
                 setSummary(R.string.aauto_app_info_summary)
-                intent = createAppInfoIntent(PKG_NAME)
+                intent = createAppInfoIntent(packageName)
             }
 
             addPref(getText(R.string.notif_listener_settings_title)).apply {
@@ -120,69 +92,6 @@ class AndroidAutoConfigFragment : PermissionsFrameFragment() {
             addAppPref("com.google.android.tts", getText(R.string.speech_services_app))
             addAppPref(PackageId.G_SEARCH_APP_NAME, getText(R.string.google_search_app))
         }
-
-        IntentFilter().run {
-            addAction(Intent.ACTION_PACKAGE_ADDED)
-            addAction(Intent.ACTION_PACKAGE_CHANGED)
-            addAction(Intent.ACTION_PACKAGE_REMOVED)
-            addDataScheme("package")
-
-            packagePrefs.keys.forEach {
-                addDataSchemeSpecificPart(it, PatternMatcher.PATTERN_LITERAL)
-            }
-
-            addDataSchemeSpecificPart(PKG_NAME, PatternMatcher.PATTERN_LITERAL)
-
-            ctx.registerReceiver(pkgChangeReceiver, this)
-        }
-
-        preferenceScreen = screen
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        requireContext().unregisterReceiver(pkgChangeReceiver)
-    }
-
-    override fun onStart() {
-        super.onStart()
-        requireActivity().setTitle(R.string.android_auto)
-        update()
-    }
-
-    fun addPkgFlagPerm(dst: PreferenceGroup, flag: Int, title: Int, confirmationText: Int, summary: Int = 0): SwitchPreferenceCompat {
-        val pref = SwitchPreferenceCompat(dst.context)
-        pref.setTitle(title)
-        if (summary != 0) {
-            pref.setSummary(summary)
-        }
-
-        pkgFlagPrefs[flag] = pref
-
-        pref.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, newValueB ->
-            val newValue = newValueB as Boolean
-
-            val ctx = requireContext()
-
-            if (newValue) {
-                AlertDialog.Builder(ctx).run {
-                    setMessage(getText(confirmationText))
-                    setPositiveButton(R.string.grant_dialog_button_allow) { _, _ ->
-                        updatePackageFlag(ctx, flag, true)
-                        update()
-                    }
-                    setNegativeButton(R.string.cancel, null)
-                    show()
-                }
-                false
-            } else {
-                updatePackageFlag(ctx, flag, false)
-                true
-            }
-        }
-
-        dst.addPreference(pref)
-        return pref
     }
 
     private fun createAppInfoIntent(pkgName: String): Intent {
@@ -198,51 +107,10 @@ class AndroidAutoConfigFragment : PermissionsFrameFragment() {
         }
     }
 
-    private fun updatePackageFlag(ctx: Context, flag: Int, flagValue: Boolean) {
-        val userId = android.os.Process.myUserHandle().identifier
-        GosPackageState.edit(PKG_NAME, userId).run {
-            setPackageFlagState(flag, flagValue)
-            applyOrPressBack()
-        }
-
-        val permManager = ctx.getSystemService(PermissionManager::class.java)!!
-        permManager.updatePermissionState(PKG_NAME, userId)
-
-        GosPackageState.edit(PKG_NAME, userId).run {
-            killUidAfterApply()
-            applyOrPressBack()
-        }
-
-        val isPkgEnabled = pkgManager.getApplicationInfo(PKG_NAME, 0).enabled
-        if (isPkgEnabled) {
-            // this is needed to invalidate cached system_server state
-            pkgManager.setApplicationEnabledSetting(PKG_NAME, PackageManager.COMPONENT_ENABLED_STATE_DISABLED, userId)
-            pkgManager.setApplicationEnabledSetting(PKG_NAME, PackageManager.COMPONENT_ENABLED_STATE_ENABLED, userId)
-
-            if (flagValue) {
-                when (flag) {
-                    AndroidAutoPackageFlag.GRANT_PERMS_FOR_WIRED_ANDROID_AUTO,
-                    AndroidAutoPackageFlag.GRANT_PERMS_FOR_WIRELESS_ANDROID_AUTO,
-                    -> {
-                        // this is needed to complete Android Auto initialization
-                        pkgManager.sendBootCompletedBroadcastToPackage(PKG_NAME, true, userId)
-                    }
-                }
-            }
-        }
-    }
-
-    fun update() {
-        val aautoAppInfo = pkgManager.getAppInfoOrNull(PKG_NAME)
-
-        if (aautoAppInfo == null) {
-            pressBack()
-            return
-        }
-
+    override fun updateNonPkgStateUi(applicationInfo: ApplicationInfo) {
         aautoSettingsPref.apply {
-            isEnabled = aautoAppInfo.enabled
-            if (aautoAppInfo.enabled) {
+            isEnabled = applicationInfo.enabled
+            if (applicationInfo.enabled) {
                 summary = null
             } else {
                 setSummary(R.string.aauto_settings_summary_disabled)
@@ -265,12 +133,6 @@ class AndroidAutoConfigFragment : PermissionsFrameFragment() {
         }
 
         potentialIssues.isVisible = aautoVoiceCommandIssues.isVisible
-
-        val ps = GosPackageState.get(PKG_NAME, requireContext().user)
-
-        pkgFlagPrefs.entries.forEach {
-            it.value.isChecked = ps.hasPackageFlag(it.key)
-        }
 
         packagePrefs.entries.forEach { e ->
             val pkgName = e.key
@@ -356,26 +218,5 @@ class AndroidAutoConfigFragment : PermissionsFrameFragment() {
             val nlsComponent = ComponentName(nls.packageName, nls.name)
             putExtra(Settings.EXTRA_NOTIFICATION_LISTENER_COMPONENT_NAME, nlsComponent.flattenToString())
         }
-    }
-
-    fun GosPackageState.Editor.applyOrPressBack() {
-        if (apply()) {
-            update()
-        } else {
-            // apply() fails only if the package is uninstalled
-            pressBack()
-        }
-    }
-
-    // it's not clear how to resolve deprecation warnings for setHasOptionsMenu and onOptionsItemSelected,
-    // they are suppressed in upstream fragments that use android.R.id.home too
-    @Suppress("DEPRECATION")
-    @Deprecated("Deprecated in Java")
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        if (item.itemId == android.R.id.home) {
-            pressBack()
-            return true
-        }
-        return super.onOptionsItemSelected(item)
     }
 }

--- a/PermissionController/src/com/android/permissioncontroller/ext/gmscore/GmsCoreConfig.kt
+++ b/PermissionController/src/com/android/permissioncontroller/ext/gmscore/GmsCoreConfig.kt
@@ -1,29 +1,15 @@
 package com.android.permissioncontroller.ext.gmscore
 
 import android.app.compat.gms.GmsCorePackageFlag
-import android.content.BroadcastReceiver
-import android.content.Context
-import android.content.Intent
-import android.content.IntentFilter
-import android.content.pm.GosPackageState
-import android.content.pm.PackageManager
+import android.content.pm.ApplicationInfo
 import android.ext.PackageId
-import android.os.Bundle
-import android.os.PatternMatcher
-import android.permission.PermissionManager
-import android.view.MenuItem
-import androidx.appcompat.app.AlertDialog
-import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
-import androidx.preference.PreferenceGroup
-import androidx.preference.SwitchPreferenceCompat
+import androidx.preference.PreferenceScreen
 import com.android.permissioncontroller.R
+import com.android.permissioncontroller.ext.BaseGosPkgStateConfigFragment
 import com.android.permissioncontroller.ext.BaseSettingsActivity
 import com.android.permissioncontroller.ext.addCategory
 import com.android.permissioncontroller.permission.ui.handheld.PermissionsCollapsingToolbarBaseFragment
-import com.android.permissioncontroller.permission.ui.handheld.PermissionsFrameFragment
-import com.android.permissioncontroller.permission.ui.handheld.pressBack
-import getAppInfoOrNull
 
 class GmsCoreConfigActivity : BaseSettingsActivity() {
     override fun getNavGraphStart() = R.id.gmscore_config
@@ -33,29 +19,11 @@ class GmsCoreConfigWrapperFragment : PermissionsCollapsingToolbarBaseFragment() 
     override fun createPreferenceFragment(): PreferenceFragmentCompat = GmsCoreConfigFragment()
 }
 
-private val PKG_NAME = PackageId.GMS_CORE_NAME
-
-class GmsCoreConfigFragment : PermissionsFrameFragment() {
-    val pkgFlagPrefs = mutableMapOf<Int, SwitchPreferenceCompat>()
-    val packagePrefs = mutableMapOf<String, Preference>()
-
-    val pkgChangeReceiver = object : BroadcastReceiver() {
-        override fun onReceive(ctx: Context, intent: Intent) {
-            update()
-        }
-    }
-
-    lateinit var pkgManager: PackageManager
-
-    override fun onCreatePreferences(savedState: Bundle?, rootKey: String?) {
-        @Suppress("DEPRECATION") // see onOptionsItemSelected
-        setHasOptionsMenu(true)
-
-        val ctx = requireContext()
-        pkgManager = ctx.packageManager
-
-        val screen = preferenceManager.createPreferenceScreen(ctx)
-
+class GmsCoreConfigFragment : BaseGosPkgStateConfigFragment(
+    packageName = PackageId.GMS_CORE_NAME,
+    titleStringRes = R.string.gmscore_settings
+) {
+    override fun configurePreferenceScreen(screen: PreferenceScreen) {
         screen.addCategory(R.string.rcs_activation_category).apply {
             addPkgFlagPerm(
                 this, GmsCorePackageFlag.GRANT_PERMS_FOR_ICC_AUTHENTICATION,
@@ -63,124 +31,7 @@ class GmsCoreConfigFragment : PermissionsFrameFragment() {
                 R.string.gmscore_icc_auth_perms_confirm,
             )
         }
-
-        IntentFilter().run {
-            addAction(Intent.ACTION_PACKAGE_ADDED)
-            addAction(Intent.ACTION_PACKAGE_CHANGED)
-            addAction(Intent.ACTION_PACKAGE_REMOVED)
-            addDataScheme("package")
-            packagePrefs.keys.forEach {
-                addDataSchemeSpecificPart(it, PatternMatcher.PATTERN_LITERAL)
-            }
-            addDataSchemeSpecificPart(PKG_NAME, PatternMatcher.PATTERN_LITERAL)
-            ctx.registerReceiver(pkgChangeReceiver, this)
-        }
-
-        preferenceScreen = screen
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
-        requireContext().unregisterReceiver(pkgChangeReceiver)
-    }
-
-    override fun onStart() {
-        super.onStart()
-        requireActivity().setTitle(R.string.gmscore_settings)
-        update()
-    }
-
-    fun addPkgFlagPerm(dst: PreferenceGroup, flag: Int, title: Int, confirmationText: Int, summary: Int = 0): SwitchPreferenceCompat {
-        val pref = SwitchPreferenceCompat(dst.context)
-        pref.setTitle(title)
-        if (summary != 0) {
-            pref.setSummary(summary)
-        }
-
-        pkgFlagPrefs[flag] = pref
-
-        pref.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, newValueB ->
-            val newValue = newValueB as Boolean
-
-            val ctx = requireContext()
-
-            if (newValue) {
-                AlertDialog.Builder(ctx).run {
-                    setMessage(getText(confirmationText))
-                    setPositiveButton(R.string.grant_dialog_button_allow) { _, _ ->
-                        updatePackageFlag(ctx, flag, true)
-                        update()
-                    }
-                    setNegativeButton(R.string.cancel, null)
-                    show()
-                }
-                false
-            } else {
-                updatePackageFlag(ctx, flag, false)
-                true
-            }
-        }
-
-        dst.addPreference(pref)
-        return pref
-    }
-
-    private fun updatePackageFlag(ctx: Context, flag: Int, flagValue: Boolean) {
-        val userId = android.os.Process.myUserHandle().identifier
-        GosPackageState.edit(PKG_NAME, userId).run {
-            setPackageFlagState(flag, flagValue)
-            applyOrPressBack()
-        }
-
-        val permManager = ctx.getSystemService(PermissionManager::class.java)!!
-        permManager.updatePermissionState(PKG_NAME, userId)
-
-        GosPackageState.edit(PKG_NAME, userId).run {
-            killUidAfterApply()
-            applyOrPressBack()
-        }
-
-        val isPkgEnabled = pkgManager.getApplicationInfo(PKG_NAME, 0).enabled
-        if (isPkgEnabled) {
-            // this is needed to invalidate cached system_server state
-            pkgManager.setApplicationEnabledSetting(PKG_NAME, PackageManager.COMPONENT_ENABLED_STATE_DISABLED, userId)
-            pkgManager.setApplicationEnabledSetting(PKG_NAME, PackageManager.COMPONENT_ENABLED_STATE_ENABLED, userId)
-        }
-    }
-
-    fun update() {
-        val gmsCoreAppInfo = pkgManager.getAppInfoOrNull(PKG_NAME)
-
-        if (gmsCoreAppInfo == null) {
-            pressBack()
-            return
-        }
-
-        val ps = GosPackageState.get(PKG_NAME, requireContext().user)
-
-        pkgFlagPrefs.entries.forEach {
-            it.value.isChecked = ps.hasPackageFlag(it.key)
-        }
-    }
-
-    fun GosPackageState.Editor.applyOrPressBack() {
-        if (apply()) {
-            update()
-        } else {
-            // apply() fails only if the package is uninstalled
-            pressBack()
-        }
-    }
-
-    // it's not clear how to resolve deprecation warnings for setHasOptionsMenu and onOptionsItemSelected,
-    // they are suppressed in upstream fragments that use android.R.id.home too
-    @Suppress("DEPRECATION")
-    @Deprecated("Deprecated in Java")
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        if (item.itemId == android.R.id.home) {
-            pressBack()
-            return true
-        }
-        return super.onOptionsItemSelected(item)
-    }
+    override fun updateNonPkgStateUi(applicationInfo: ApplicationInfo) {}
 }

--- a/PermissionController/src/com/android/permissioncontroller/ext/gmscore/GmsCoreConfig.kt
+++ b/PermissionController/src/com/android/permissioncontroller/ext/gmscore/GmsCoreConfig.kt
@@ -1,0 +1,186 @@
+package com.android.permissioncontroller.ext.gmscore
+
+import android.app.compat.gms.GmsCorePackageFlag
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.GosPackageState
+import android.content.pm.PackageManager
+import android.ext.PackageId
+import android.os.Bundle
+import android.os.PatternMatcher
+import android.permission.PermissionManager
+import android.view.MenuItem
+import androidx.appcompat.app.AlertDialog
+import androidx.preference.Preference
+import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.PreferenceGroup
+import androidx.preference.SwitchPreferenceCompat
+import com.android.permissioncontroller.R
+import com.android.permissioncontroller.ext.BaseSettingsActivity
+import com.android.permissioncontroller.ext.addCategory
+import com.android.permissioncontroller.permission.ui.handheld.PermissionsCollapsingToolbarBaseFragment
+import com.android.permissioncontroller.permission.ui.handheld.PermissionsFrameFragment
+import com.android.permissioncontroller.permission.ui.handheld.pressBack
+import getAppInfoOrNull
+
+class GmsCoreConfigActivity : BaseSettingsActivity() {
+    override fun getNavGraphStart() = R.id.gmscore_config
+}
+
+class GmsCoreConfigWrapperFragment : PermissionsCollapsingToolbarBaseFragment() {
+    override fun createPreferenceFragment(): PreferenceFragmentCompat = GmsCoreConfigFragment()
+}
+
+private val PKG_NAME = PackageId.GMS_CORE_NAME
+
+class GmsCoreConfigFragment : PermissionsFrameFragment() {
+    val pkgFlagPrefs = mutableMapOf<Int, SwitchPreferenceCompat>()
+    val packagePrefs = mutableMapOf<String, Preference>()
+
+    val pkgChangeReceiver = object : BroadcastReceiver() {
+        override fun onReceive(ctx: Context, intent: Intent) {
+            update()
+        }
+    }
+
+    lateinit var pkgManager: PackageManager
+
+    override fun onCreatePreferences(savedState: Bundle?, rootKey: String?) {
+        @Suppress("DEPRECATION") // see onOptionsItemSelected
+        setHasOptionsMenu(true)
+
+        val ctx = requireContext()
+        pkgManager = ctx.packageManager
+
+        val screen = preferenceManager.createPreferenceScreen(ctx)
+
+        screen.addCategory(R.string.rcs_activation_category).apply {
+            addPkgFlagPerm(
+                this, GmsCorePackageFlag.GRANT_PERMS_FOR_ICC_AUTHENTICATION,
+                R.string.gmscore_icc_auth_perms_title,
+                R.string.gmscore_icc_auth_perms_confirm,
+            )
+        }
+
+        IntentFilter().run {
+            addAction(Intent.ACTION_PACKAGE_ADDED)
+            addAction(Intent.ACTION_PACKAGE_CHANGED)
+            addAction(Intent.ACTION_PACKAGE_REMOVED)
+            addDataScheme("package")
+            packagePrefs.keys.forEach {
+                addDataSchemeSpecificPart(it, PatternMatcher.PATTERN_LITERAL)
+            }
+            addDataSchemeSpecificPart(PKG_NAME, PatternMatcher.PATTERN_LITERAL)
+            ctx.registerReceiver(pkgChangeReceiver, this)
+        }
+
+        preferenceScreen = screen
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        requireContext().unregisterReceiver(pkgChangeReceiver)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        requireActivity().setTitle(R.string.gmscore_settings)
+        update()
+    }
+
+    fun addPkgFlagPerm(dst: PreferenceGroup, flag: Int, title: Int, confirmationText: Int, summary: Int = 0): SwitchPreferenceCompat {
+        val pref = SwitchPreferenceCompat(dst.context)
+        pref.setTitle(title)
+        if (summary != 0) {
+            pref.setSummary(summary)
+        }
+
+        pkgFlagPrefs[flag] = pref
+
+        pref.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, newValueB ->
+            val newValue = newValueB as Boolean
+
+            val ctx = requireContext()
+
+            if (newValue) {
+                AlertDialog.Builder(ctx).run {
+                    setMessage(getText(confirmationText))
+                    setPositiveButton(R.string.grant_dialog_button_allow) { _, _ ->
+                        updatePackageFlag(ctx, flag, true)
+                        update()
+                    }
+                    setNegativeButton(R.string.cancel, null)
+                    show()
+                }
+                false
+            } else {
+                updatePackageFlag(ctx, flag, false)
+                true
+            }
+        }
+
+        dst.addPreference(pref)
+        return pref
+    }
+
+    private fun updatePackageFlag(ctx: Context, flag: Int, flagValue: Boolean) {
+        val userId = android.os.Process.myUserHandle().identifier
+        GosPackageState.edit(PKG_NAME, userId).run {
+            setPackageFlagState(flag, flagValue)
+            applyOrPressBack()
+        }
+
+        val permManager = ctx.getSystemService(PermissionManager::class.java)!!
+        permManager.updatePermissionState(PKG_NAME, userId)
+
+        GosPackageState.edit(PKG_NAME, userId).run {
+            killUidAfterApply()
+            applyOrPressBack()
+        }
+
+        val isPkgEnabled = pkgManager.getApplicationInfo(PKG_NAME, 0).enabled
+        if (isPkgEnabled) {
+            // this is needed to invalidate cached system_server state
+            pkgManager.setApplicationEnabledSetting(PKG_NAME, PackageManager.COMPONENT_ENABLED_STATE_DISABLED, userId)
+            pkgManager.setApplicationEnabledSetting(PKG_NAME, PackageManager.COMPONENT_ENABLED_STATE_ENABLED, userId)
+        }
+    }
+
+    fun update() {
+        val gmsCoreAppInfo = pkgManager.getAppInfoOrNull(PKG_NAME)
+
+        if (gmsCoreAppInfo == null) {
+            pressBack()
+            return
+        }
+
+        val ps = GosPackageState.get(PKG_NAME, requireContext().user)
+
+        pkgFlagPrefs.entries.forEach {
+            it.value.isChecked = ps.hasPackageFlag(it.key)
+        }
+    }
+
+    fun GosPackageState.Editor.applyOrPressBack() {
+        if (apply()) {
+            update()
+        } else {
+            // apply() fails only if the package is uninstalled
+            pressBack()
+        }
+    }
+
+    // it's not clear how to resolve deprecation warnings for setHasOptionsMenu and onOptionsItemSelected,
+    // they are suppressed in upstream fragments that use android.R.id.home too
+    @Suppress("DEPRECATION")
+    @Deprecated("Deprecated in Java")
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            pressBack()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
+    }
+}


### PR DESCRIPTION
Change set:
- https://github.com/GrapheneOS/platform_frameworks_base/pull/308
- https://github.com/GrapheneOS/platform_packages_apps_GmsCompat/pull/269

See: 
- https://github.com/GrapheneOS/os-issue-tracker/issues/6973
- https://github.com/GrapheneOS/os-issue-tracker/issues/6331
- https://github.com/GrapheneOS/os-issue-tracker/issues/6173
- https://discuss.grapheneos.org/d/1353-using-rcs-with-google-messages-on-grapheneos

This adds a toggle under Settings -> Apps -> Sandboxed Google Play -> Play services special permissions to allow Play services to perform ICC authentication with the SIM. This is achieved by using the preexisting `USE_ICC_AUTH_WITH_DEVICE_IDENTIFIER` permission which is more narrower than `READ_PRIVILEGED_PHONE_STATE`.

Some carriers require an entitlement check (GSMA TS.43 with EAP-AKA authentication) to activate RCS in Google Messages. This new limited permission allows Google Play services to use the SIM to complete the EAP-AKA challenge-response from the carrier's entitlement server (`TelephonyManager#getIccAuthentication`). 

From the source code, it appears to roughly follow GSM specs. e.g. see section 2.8.1 of TS.43 [^1] which references RCC.14. Anex D of RCC.14[^2] provides a reference flow specifically for RCS with EAP-AKA authentication. The AOSP docs [^3] give a high-level overview of TS.43 with reference to AOSP API, i.e. using `TelephonyManager#getIccAuthentication` to complete an EAP-AKA challenge from the TS.43 server. It appears GmsCore does in fact call this in order to complete EAP-AKA authentication for a temporary token as noted in Anex D of RCC.14.

TS.43 usage is evident in logcat for GmsCore when trying to activate RCS on a Tello eSIM. `adb shell setprop log.tag.constellation VERBOSE` (note that this WILL print IMSIs, phone numbers, etc.) reveals more information during the verification process:

```
 3224-7955  constellation            D  [verification_manager] Performing legacy sequential verification
 3224-7955  constellation            D  [verification_manager] Getting flash call receiver
 3224-7955  constellation            V  [verification factory] get verifier for verification # hwzo@5d392675
 3224-7955  constellation            I  [verification factory] Doing TS43 verification
 3224-7955  constellation            D  [verification_manager] Starting sequential verification with 3 max attempts
 3224-7955  constellation            D  [verification_manager] Attempt: 1 - Current verification state: PENDING
 3224-7955  constellation            D  [verification_manager] Attempt: 1 - Current Challenge ID: , Type: TS43
 3224-7955  constellation            I  [verification_manager] Proceeding with verification
 3224-7955  constellation            V  [telephony_info_provider] Doesn't have carrier id permission.
 3224-7955  constellation            D  [carrierIdTs43_verifier] CarrierId is not supported
```

"CarrierId is not supported" and "Doesn't have carrier id permission" are printed when the permission check for `READ_PRIVILEGED_PHONE_STATE` fails. When this happens, the `carrierIdTs43_verifier` does not run any of its verification code, since it needs this permission to call `TelephonyManager#getIccAuthentication` to complete EAP-AKA authentication.

Carrier configs are revealed in the Google Messages debug menu (searching for `*xyzzy*` in Google Messages) -> RCS -> Configure MobileConfiguration. Then tap on your SIM between the Force Sync and Refresh buttons. 

On version 20260119_02_RC00 of Google Messages,

- For Tello (issues with RCS activation without this change), `upi_policy_id` is `upi-carrier-tos-ts43`, and and is_ts43_supported is `true`
- For Fizz Mobile (no issues with RCS activation), `upi_policy_id` is `upi-mo-relax-policy-mt-non-priority`, and `is_ts43_supported` is `false`. MT verification stands for incoming SMS verification.

Note that an older version 20241120_00_RC07 of Google Messages,

- For Tello (no issues with RCS activation, but can't start RCS chats in old version), `upi_policy_id` is `upi-mo-strict-policy-mt-priority`

Test: Tello eSIM (T-Mobile MVNO) was able to succeed TS43 verification and activate RCS in Google Messages on version `messages.android_20260119_02_RC00.phone_dynamic`, versionCode 298032063. Was able to make end-to-end encrypted RCS chats with non-GrapheneOS Android numbers

[^1]: https://www.gsma.com/get-involved/working-groups/wp-content/uploads/2026/02/TS.43v13.0-Service-Entitlement-Configuration.pdf
[^2]: https://www.gsma.com/solutions-and-impact/technologies/networks/wp-content/uploads/2024/07/RCC.14-v10.0-1.pdf
[^3]: https://source.android.com/docs/core/connect/ims-service-entitlement#architecture