### PR TITLE
#2133 Add PermissionController mic spoofing UI and links

### DIFF
--- a/PermissionController/AndroidManifest.xml
+++ b/PermissionController/AndroidManifest.xml
@@ -738,6 +738,11 @@
             android:permission="android.permission.WRITE_SECURE_SETTINGS"
             android:exported="true" />
 
+        <activity
+            android:name="com.android.permissioncontroller.micspoofing.MicSpoofingActivity"
+            android:exported="true"
+            android:permission="android.permission.WRITE_SECURE_SETTINGS"
+            android:theme="@style/Theme.PermissionController.Settings.Expressive.FilterTouches" />
 
         <activity
             android:name="com.android.permissioncontroller.ext.aauto.AndroidAutoConfigActivity"

--- a/PermissionController/res/navigation/nav_graph.xml
+++ b/PermissionController/res/navigation/nav_graph.xml
@@ -202,6 +202,10 @@
         android:name="com.android.permissioncontroller.cscopes.ContactScopesWrapperFragment"
         android:label="ContactScopes"/>
 
+    <fragment
+        android:id="@+id/mic_spoofing"
+        android:name="com.android.permissioncontroller.micspoofing.MicSpoofingWrapperFragment"
+        android:label="MicSpoofing"/>
 
     <fragment
         android:id="@+id/android_auto_config"

--- a/PermissionController/res/values/strings_mic_spoofing.xml
+++ b/PermissionController/res/values/strings_mic_spoofing.xml
@@ -6,15 +6,14 @@
     <string name="mic_spoofing_enable">Enable Microphone Spoofing</string>
     <string name="mic_spoofing_source">Audio source</string>
     <string name="mic_spoofing_source_default">Default (Silence)</string>
-    <string name="mic_spoofing_source_choose_custom_file">Custom file</string>
-    <string name="mic_spoofing_source_custom_fallback">Custom WAV</string>
+    <string name="mic_spoofing_source_choose_custom_file">Choose custom audio file</string>
+    <string name="mic_spoofing_source_custom_fallback">Custom audio file</string>
 
-    <string name="mic_spoofing_footer_disabled">When enabled, Microphone Spoofing replaces app microphone input with silence or audio from a WAV file.</string>
+    <string name="mic_spoofing_footer_disabled">When enabled, Microphone Spoofing replaces app microphone input with silence or audio from a custom audio file.</string>
     <string name="mic_spoofing_footer_enabled_default">Microphone Spoofing is enabled. Replacing microphone input with silence.</string>
     <string name="mic_spoofing_footer_enabled_custom">Microphone Spoofing is enabled. Replacing microphone input with %1$s.</string>
 
     <string name="mic_spoofing_toast_picker_not_found">File picker app not found</string>
-    <string name="mic_spoofing_toast_invalid_wav">Selected file is not a valid WAV file</string>
-    <string name="mic_spoofing_toast_wav_too_large">Selected WAV file exceeds 100 MB</string>
+    <string name="mic_spoofing_toast_invalid_audio">Selected file is not a supported audio file</string>
     <string name="mic_spoofing_toast_invalid_location">Invalid file location</string>
 </resources>

--- a/PermissionController/res/values/strings_mic_spoofing.xml
+++ b/PermissionController/res/values/strings_mic_spoofing.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="microphone_spoofing">Microphone Spoofing</string>
+    <string name="setup_microphone_spoofing">Set up microphone spoofing</string>
+
+    <string name="mic_spoofing_enable">Enable Microphone Spoofing</string>
+    <string name="mic_spoofing_source">Audio source</string>
+    <string name="mic_spoofing_source_default">Default (Silence)</string>
+    <string name="mic_spoofing_source_choose_custom_file">Custom file</string>
+    <string name="mic_spoofing_source_custom_fallback">Custom WAV</string>
+
+    <string name="mic_spoofing_footer_disabled">When enabled, Microphone Spoofing replaces app microphone input with silence or audio from a WAV file.</string>
+    <string name="mic_spoofing_footer_enabled_default">Microphone Spoofing is enabled. Replacing microphone input with silence.</string>
+    <string name="mic_spoofing_footer_enabled_custom">Microphone Spoofing is enabled. Replacing microphone input with %1$s.</string>
+
+    <string name="mic_spoofing_toast_picker_not_found">File picker app not found</string>
+    <string name="mic_spoofing_toast_invalid_wav">Selected file is not a valid WAV file</string>
+    <string name="mic_spoofing_toast_wav_too_large">Selected WAV file exceeds 100 MB</string>
+    <string name="mic_spoofing_toast_invalid_location">Invalid file location</string>
+</resources>

--- a/PermissionController/src/com/android/permissioncontroller/ext/StoragePathUtils.kt
+++ b/PermissionController/src/com/android/permissioncontroller/ext/StoragePathUtils.kt
@@ -1,0 +1,113 @@
+@file:JvmName("StoragePathUtils")
+
+package com.android.permissioncontroller.ext
+
+import android.content.Context
+import android.net.Uri
+import android.os.storage.StorageManager
+import android.os.storage.StorageVolume
+import android.system.Os
+import android.util.Log
+import java.io.File
+import java.nio.charset.StandardCharsets
+
+private const val TAG = "StoragePathUtils"
+
+private const val MAX_PATH_LENGTH_IN_UTF8_BYTES = 4096
+
+fun storageVolumeForPath(
+    context: Context,
+    file: File,
+    cachedVolumes: List<StorageVolume>?,
+): StorageVolume? {
+    val volumes = cachedVolumes
+        ?: context.getSystemService(StorageManager::class.java)?.storageVolumes
+        ?: run {
+            Log.w(TAG, "No storage volumes found")
+            return null
+        }
+
+    volumes.forEach { volume ->
+        volume.directory?.let { volumeRoot ->
+            if (dirContainsOrEquals(volumeRoot, file)) {
+                return volume
+            }
+        }
+    }
+
+    return null
+}
+
+fun validatePathBasics(path: String?): Boolean {
+    if (path == null) {
+        return false
+    }
+
+    if (!StringUtils.isUtf16(path)) {
+        return false
+    }
+
+    if (path.indexOf('\u0000') >= 0) {
+        return false
+    }
+
+    val components = path.split("/")
+    if (components.size < 2) {
+        return false
+    }
+
+    if (components[0].isNotEmpty()) {
+        return false
+    }
+
+    for (i in 1 until components.size) {
+        if (components[i].isEmpty()) {
+            return false
+        }
+    }
+
+    if (path.toByteArray(StandardCharsets.UTF_8).size > MAX_PATH_LENGTH_IN_UTF8_BYTES) {
+        return false
+    }
+
+    return true
+}
+
+fun resolveFileUriToPath(context: Context, uri: Uri): String? {
+    return try {
+        context.contentResolver.openFileDescriptor(uri, "r")?.use { parcelFileDescriptor ->
+            val fdPath = "/proc/self/fd/${parcelFileDescriptor.fd}"
+            var realPath = Os.readlink(fdPath)
+            val userId = context.user.identifier
+            val mntUserPrefix = "/mnt/user/$userId/"
+
+            if (realPath.startsWith(mntUserPrefix)) {
+                realPath = realPath.replaceFirst(mntUserPrefix, "/storage/")
+            }
+
+            if (File(realPath).isFile) {
+                realPath
+            } else {
+                Log.d(TAG, "$realPath is not a file")
+                null
+            }
+        }
+    } catch (e: Exception) {
+        Log.w(TAG, "Unable to convert uri $uri to path", e)
+        null
+    }
+}
+
+private fun dirContainsOrEquals(dir: File, file: File): Boolean {
+    var current: File? = file
+
+    while (current != null) {
+        if (current == dir) {
+            return true
+        }
+
+        current = current.parentFile
+    }
+
+    return false
+}

--- a/PermissionController/src/com/android/permissioncontroller/micspoofing/MicSpoofingActivity.kt
+++ b/PermissionController/src/com/android/permissioncontroller/micspoofing/MicSpoofingActivity.kt
@@ -1,0 +1,8 @@
+package com.android.permissioncontroller.micspoofing
+
+import com.android.permissioncontroller.R
+import com.android.permissioncontroller.ext.PackageExtraConfigActivity
+
+class MicSpoofingActivity : PackageExtraConfigActivity() {
+    override fun getNavGraphStart() = R.id.mic_spoofing
+}

--- a/PermissionController/src/com/android/permissioncontroller/micspoofing/MicSpoofingAudioFileUtils.kt
+++ b/PermissionController/src/com/android/permissioncontroller/micspoofing/MicSpoofingAudioFileUtils.kt
@@ -1,0 +1,94 @@
+package com.android.permissioncontroller.micspoofing
+
+import android.content.Intent
+import android.provider.DocumentsContract
+import androidx.annotation.VisibleForTesting
+import java.io.File
+import java.io.InputStream
+import java.util.Locale
+
+@VisibleForTesting
+const val AUDIO_PICKER_MIME_TYPE = "audio/*"
+
+@VisibleForTesting
+val AUDIO_PICKER_MIME_TYPES = arrayOf(
+    "audio/wav",
+    "audio/x-wav",
+    "audio/mpeg",
+    "audio/ogg",
+    "audio/opus",
+    "audio/flac",
+    "audio/x-flac",
+    "audio/mp4",
+    "audio/aac",
+    "audio/x-m4a",
+    "audio/m4a",
+    "audio/mp4a-latm",
+)
+
+@VisibleForTesting
+val PLAUSIBLE_AUDIO_FILE_EXTENSIONS = setOf(
+    "wav",
+    "mp3",
+    "ogg",
+    "oga",
+    "opus",
+    "flac",
+    "aac",
+    "m4a",
+    "mp4",
+)
+
+fun createPickerIntent(): Intent {
+    return Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+        type = AUDIO_PICKER_MIME_TYPE
+        addCategory(Intent.CATEGORY_OPENABLE)
+        putExtra(Intent.EXTRA_MIME_TYPES, AUDIO_PICKER_MIME_TYPES)
+        putStringArrayListExtra(
+            Intent.EXTRA_RESTRICTIONS_LIST,
+            arrayListOf(
+                DocumentsContract.EXTERNAL_STORAGE_PROVIDER_AUTHORITY,
+                "com.android.providers.media.documents",
+                "com.android.providers.downloads.documents",
+            ),
+        )
+    }
+}
+
+fun isPlausibleAudioFile(mimeType: String?, path: String): Boolean {
+    return hasPlausibleAudioMimeType(mimeType) || hasPlausibleAudioFileExtension(path)
+}
+
+@VisibleForTesting
+fun probeReadableAndNonEmptyContent(
+    assetLength: Long?,
+    openInputStream: () -> InputStream?,
+): Boolean? {
+    if (assetLength != null && assetLength >= 0) {
+        return assetLength > 0
+    }
+
+    openInputStream().use { input ->
+        return input?.read()?.let { it >= 0 }
+    }
+}
+
+private fun hasPlausibleAudioMimeType(mimeType: String?): Boolean {
+    val normalizedMimeType = normalizeMimeType(mimeType) ?: return false
+    return normalizedMimeType.startsWith("audio/") || normalizedMimeType == "application/ogg"
+}
+
+private fun hasPlausibleAudioFileExtension(path: String): Boolean {
+    return File(path)
+        .extension
+        .lowercase(Locale.ROOT)
+        .let(PLAUSIBLE_AUDIO_FILE_EXTENSIONS::contains)
+}
+
+private fun normalizeMimeType(mimeType: String?): String? {
+    return mimeType
+        ?.substringBefore(';')
+        ?.trim()
+        ?.lowercase(Locale.ROOT)
+        ?.takeIf { it.isNotBlank() }
+}

--- a/PermissionController/src/com/android/permissioncontroller/micspoofing/MicSpoofingFragment.kt
+++ b/PermissionController/src/com/android/permissioncontroller/micspoofing/MicSpoofingFragment.kt
@@ -1,0 +1,424 @@
+package com.android.permissioncontroller.micspoofing
+
+import android.Manifest
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.content.pm.GosPackageState
+import android.content.pm.GosPackageStateFlag
+import android.ext.micspoofing.MicSpoofingApi
+import android.net.Uri
+import android.os.Bundle
+import android.os.storage.StorageManager
+import android.provider.DocumentsContract
+import android.util.Log
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.lifecycle.lifecycleScope
+import com.android.permissioncontroller.R
+import com.android.permissioncontroller.ext.PackageExtraConfigFragment
+import com.android.permissioncontroller.ext.ScopesUtils
+import com.android.permissioncontroller.ext.addOrRemove
+import com.android.permissioncontroller.ext.createFooterPreference
+import com.android.permissioncontroller.permission.ui.handheld.PermissionPreference
+import com.android.permissioncontroller.permission.ui.handheld.PermissionPreferenceCategory
+import com.android.permissioncontroller.permission.ui.handheld.pressBack
+import com.android.permissioncontroller.permission.ui.handheld.v36.PermissionSelectorWithWidgetPreference
+import com.android.settingslib.widget.FooterPreference
+import com.android.settingslib.widget.MainSwitchPreference
+import java.io.File
+import java.io.IOException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class MicSpoofingFragment : PackageExtraConfigFragment() {
+
+    private lateinit var mainSwitch: MainSwitchPreference
+    private lateinit var sourceCategory: PermissionPreferenceCategory
+    private lateinit var footer: FooterPreference
+
+    private var chooseWavJob: Job? = null
+
+    private val chooseWavLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            result.data?.data?.let(::onChooseWavResult)
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        mainSwitch = MainSwitchPreference(context_).apply {
+            setTitle(R.string.mic_spoofing_enable)
+            setOnPreferenceChangeListener { _, newValue ->
+                setMicSpoofingEnabled(newValue == true)
+                false
+            }
+        }
+
+        sourceCategory = PermissionPreferenceCategory(context_).apply {
+            title = getText(R.string.mic_spoofing_source)
+        }
+
+        footer = createFooterPreference()
+
+        update()
+    }
+
+    override fun update() {
+        val packageState = getGosPackageState()
+        val enabled = packageState.hasFlag(GosPackageStateFlag.MIC_SPOOFING_ENABLED)
+
+        mainSwitch.isChecked = enabled
+
+        addOrRemove(mainSwitch, true)
+        addOrRemove(sourceCategory, enabled)
+        if (enabled) {
+            updateSourceCategory(packageState)
+        }
+
+        footer.summary = getFooterSummary(packageState, enabled)
+        addOrRemove(footer, true)
+    }
+
+    override fun onDestroy() {
+        chooseWavJob?.cancel()
+        chooseWavJob = null
+
+        super.onDestroy()
+    }
+
+    private fun onSourceSelected(selectedValue: String) {
+        when (selectedValue) {
+            SOURCE_VALUE_DEFAULT -> useDefaultWav()
+            SOURCE_VALUE_CHOOSE_CUSTOM_FILE -> launchWavPicker()
+        }
+    }
+
+    private fun updateSourceCategory(packageState: GosPackageState) {
+        val currentPath = MicSpoofingApi.getPath(packageState.micSpoofingConfig)
+        val entries = mutableListOf<SourceEntry>()
+
+        entries.add(
+            SourceEntry(
+                value = SOURCE_VALUE_DEFAULT,
+                label = getString(R.string.mic_spoofing_source_default),
+            ),
+        )
+
+        if (currentPath != null) {
+            entries.add(
+                SourceEntry(
+                    value = currentPath,
+                    label = getCustomSourceDisplayName(currentPath),
+                ),
+            )
+        }
+
+        entries.add(
+            SourceEntry(
+                value = SOURCE_VALUE_CHOOSE_CUSTOM_FILE,
+                label = getString(R.string.mic_spoofing_source_choose_custom_file),
+            ),
+        )
+
+        val selectedValue = currentPath ?: SOURCE_VALUE_DEFAULT
+        renderSourceEntries(entries, selectedValue)
+    }
+
+    private fun createSourceOptionPreference(
+        entry: SourceEntry,
+        checked: Boolean,
+    ): PermissionSelectorWithWidgetPreference {
+        return PermissionSelectorWithWidgetPreference(context_).apply {
+            title = entry.label
+            isChecked = checked
+            setOnClickListener {
+                if (!checked) {
+                    onSourceSelected(entry.value)
+                }
+            }
+        }
+    }
+
+    private fun createChooseCustomFilePreference(entry: SourceEntry): PermissionPreference {
+        return PermissionPreference(context_).apply {
+            title = entry.label
+            setIcon(R.drawable.ic_settings_open)
+            setOnPreferenceClickListener {
+                launchWavPicker()
+                true
+            }
+        }
+    }
+
+    private fun renderSourceEntries(entries: List<SourceEntry>, selectedValue: String) {
+        sourceCategory.removeAll()
+        for (entry in entries) {
+            if (entry.value == SOURCE_VALUE_CHOOSE_CUSTOM_FILE) {
+                sourceCategory.addPreference(createChooseCustomFilePreference(entry))
+            } else {
+                sourceCategory.addPreference(
+                    createSourceOptionPreference(entry, selectedValue == entry.value),
+                )
+            }
+        }
+    }
+
+    private fun setMicSpoofingEnabled(enabled: Boolean) {
+        if (enabled) {
+            ScopesUtils.revokePermissions(
+                context_,
+                pkgName,
+                listOf(Manifest.permission.RECORD_AUDIO),
+            )
+        }
+
+        GosPackageState.edit(pkgName, context_.user).run {
+            setFlagState(GosPackageStateFlag.MIC_SPOOFING_ENABLED, enabled)
+            setNotifyUidAfterApply(true)
+            applyOrPressBack()
+        }
+    }
+
+    private fun launchWavPicker() {
+        try {
+            val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+                type = MIME_AUDIO_WAV
+                addCategory(Intent.CATEGORY_OPENABLE)
+                putExtra(Intent.EXTRA_MIME_TYPES, arrayOf(MIME_AUDIO_WAV, MIME_AUDIO_X_WAV))
+                putStringArrayListExtra(
+                    Intent.EXTRA_RESTRICTIONS_LIST,
+                    arrayListOf(
+                        DocumentsContract.EXTERNAL_STORAGE_PROVIDER_AUTHORITY,
+                        "com.android.providers.media.documents",
+                        "com.android.providers.downloads.documents",
+                    ),
+                )
+            }
+            chooseWavLauncher.launch(intent)
+        } catch (e: ActivityNotFoundException) {
+            Log.w(TAG, "Unable to launch document picker for WAV source selection", e)
+            toastManager.showToast(R.string.mic_spoofing_toast_picker_not_found)
+        }
+    }
+
+    private fun onChooseWavResult(uri: Uri) {
+        chooseWavJob?.cancel()
+        chooseWavJob = lifecycleScope.launch {
+            if (!validateSelectedWav(uri)) {
+                return@launch
+            }
+
+            val path = withContext(Dispatchers.IO) {
+                convertUriToPath(uri)
+            }
+            if (path == null) {
+                toastManager.showToast(R.string.mic_spoofing_toast_invalid_location)
+                return@launch
+            }
+
+            val oldState = getGosPackageState()
+            val newConfig = MicSpoofingApi.buildCustomPathConfig(path)
+
+            val applied = oldState.createEditor(pkgName, context_.user).run {
+                setMicSpoofingConfig(newConfig)
+                setNotifyUidAfterApply(true)
+                apply()
+            }
+
+            if (!applied) {
+                Log.w(TAG, "Failed to apply custom mic spoofing config")
+                pressBack()
+                return@launch
+            }
+
+            update()
+        }
+    }
+
+    private fun useDefaultWav() {
+        val packageState = getGosPackageState()
+        val applied = applyMicSpoofingConfig(packageState, null)
+
+        if (!applied) {
+            Log.w(TAG, "Failed to apply default mic spoofing configuration")
+            pressBack()
+            return
+        }
+
+        update()
+    }
+
+    private suspend fun validateSelectedWav(uri: Uri): Boolean {
+        val validationError = withContext(Dispatchers.IO) {
+            validateWavUri(uri)
+        }
+        if (validationError == 0) {
+            return true
+        }
+        Log.w(TAG, "Selected WAV source failed validation: errorResId=$validationError")
+        toastManager.showToast(validationError)
+        return false
+    }
+
+    private fun convertUriToPath(uri: Uri): String? {
+        return fileUriToPath(
+            context = context_,
+            uri = uri,
+            cachedVolumes = context_
+                .getSystemService(StorageManager::class.java)
+                ?.storageVolumes,
+        )
+    }
+
+    private fun validateWavUri(uri: Uri): Int {
+        val fileSize = getFileSize(uri) ?: return R.string.mic_spoofing_toast_invalid_wav
+        if (fileSize > MAX_WAV_FILE_SIZE_BYTES) {
+            return R.string.mic_spoofing_toast_wav_too_large
+        }
+        if (!hasWavHeader(uri)) {
+            return R.string.mic_spoofing_toast_invalid_wav
+        }
+        return 0
+    }
+
+    private fun getFileSize(uri: Uri): Long? {
+        try {
+            context_.contentResolver.openAssetFileDescriptor(uri, "r")?.use { afd ->
+                if (afd.length >= 0) {
+                    return afd.length
+                }
+            }
+
+            context_.contentResolver.openInputStream(uri)?.use { input ->
+                val buffer = ByteArray(8 * 1024)
+                var total = 0L
+                while (true) {
+                    val count = input.read(buffer)
+                    if (count < 0) {
+                        break
+                    }
+                    total += count
+                    if (total > MAX_WAV_FILE_SIZE_BYTES) {
+                        break
+                    }
+                }
+                return total
+            }
+        } catch (e: IOException) {
+            Log.w(TAG, "Failed to read selected file size", e)
+            return null
+        } catch (e: SecurityException) {
+            Log.w(TAG, "No permission to read selected file size", e)
+            return null
+        }
+
+        return null
+    }
+
+    private fun hasWavHeader(uri: Uri): Boolean {
+        val header = ByteArray(12)
+        try {
+            context_.contentResolver.openInputStream(uri)?.use { input ->
+                var read = 0
+                while (read < header.size) {
+                    val count = input.read(header, read, header.size - read)
+                    if (count < 0) {
+                        Log.w(TAG, "Selected WAV source is too short to contain full header")
+                        return false
+                    }
+                    read += count
+                }
+            } ?: return false
+        } catch (e: IOException) {
+            Log.w(TAG, "Failed to read WAV header", e)
+            return false
+        } catch (e: SecurityException) {
+            Log.w(TAG, "No permission to read WAV header", e)
+            return false
+        }
+
+        return checkMagicBytes(header, 0, RIFF_MAGIC) &&
+                checkMagicBytes(header, 8, WAVE_MAGIC)
+    }
+
+    private fun applyMicSpoofingConfig(
+        packageState: GosPackageState,
+        config: ByteArray?,
+    ): Boolean {
+        return packageState.createEditor(pkgName, context_.user).run {
+            setMicSpoofingConfig(config)
+            setNotifyUidAfterApply(true)
+            apply()
+        }
+    }
+
+    private fun checkMagicBytes(
+        header: ByteArray,
+        startIndex: Int,
+        magic: String,
+    ): Boolean {
+        if (header.size < startIndex + magic.length) {
+            return false
+        }
+
+        for (i in magic.indices) {
+            if (header[startIndex + i] != magic[i].code.toByte()) {
+                return false
+            }
+        }
+
+        return true
+    }
+
+    private fun getFooterSummary(packageState: GosPackageState, enabled: Boolean): CharSequence {
+        if (!enabled) {
+            return getText(R.string.mic_spoofing_footer_disabled)
+        }
+
+        val path = MicSpoofingApi.getPath(packageState.micSpoofingConfig)
+        if (path != null) {
+            return getString(
+                R.string.mic_spoofing_footer_enabled_custom,
+                getCustomSourceDisplayName(path),
+            )
+        }
+
+        return getText(R.string.mic_spoofing_footer_enabled_default)
+    }
+
+    private fun getCustomSourceDisplayName(path: String): String {
+        return File(path).name.ifEmpty { fallbackSourceName() }
+    }
+
+    private fun fallbackSourceName(): String {
+        return getString(R.string.mic_spoofing_source_custom_fallback)
+    }
+
+    override fun getTitle(): CharSequence {
+        return getText(R.string.microphone_spoofing)
+    }
+
+    private data class SourceEntry(
+        val value: String,
+        val label: String,
+    )
+
+    private companion object {
+        private const val TAG = "MicSpoofingFragment"
+
+        private const val MAX_WAV_FILE_SIZE_BYTES = 100L * 1024 * 1024
+        private const val MIME_AUDIO_WAV = "audio/wav"
+        private const val MIME_AUDIO_X_WAV = "audio/x-wav"
+
+        private const val SOURCE_VALUE_DEFAULT = "__default__"
+        private const val SOURCE_VALUE_CHOOSE_CUSTOM_FILE = "__choose_custom_file__"
+
+        private const val RIFF_MAGIC = "RIFF"
+        private const val WAVE_MAGIC = "WAVE"
+    }
+}

--- a/PermissionController/src/com/android/permissioncontroller/micspoofing/MicSpoofingFragment.kt
+++ b/PermissionController/src/com/android/permissioncontroller/micspoofing/MicSpoofingFragment.kt
@@ -3,14 +3,12 @@ package com.android.permissioncontroller.micspoofing
 import android.Manifest
 import android.app.Activity
 import android.content.ActivityNotFoundException
-import android.content.Intent
 import android.content.pm.GosPackageState
 import android.content.pm.GosPackageStateFlag
 import android.ext.micspoofing.MicSpoofingApi
 import android.net.Uri
 import android.os.Bundle
 import android.os.storage.StorageManager
-import android.provider.DocumentsContract
 import android.util.Log
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.lifecycle.lifecycleScope
@@ -38,13 +36,13 @@ class MicSpoofingFragment : PackageExtraConfigFragment() {
     private lateinit var sourceCategory: PermissionPreferenceCategory
     private lateinit var footer: FooterPreference
 
-    private var chooseWavJob: Job? = null
+    private var chooseAudioFileJob: Job? = null
 
-    private val chooseWavLauncher = registerForActivityResult(
+    private val chooseAudioFileLauncher = registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) { result ->
         if (result.resultCode == Activity.RESULT_OK) {
-            result.data?.data?.let(::onChooseWavResult)
+            result.data?.data?.let(::onChooseAudioFileResult)
         }
     }
 
@@ -85,16 +83,16 @@ class MicSpoofingFragment : PackageExtraConfigFragment() {
     }
 
     override fun onDestroy() {
-        chooseWavJob?.cancel()
-        chooseWavJob = null
+        chooseAudioFileJob?.cancel()
+        chooseAudioFileJob = null
 
         super.onDestroy()
     }
 
     private fun onSourceSelected(selectedValue: String) {
         when (selectedValue) {
-            SOURCE_VALUE_DEFAULT -> useDefaultWav()
-            SOURCE_VALUE_CHOOSE_CUSTOM_FILE -> launchWavPicker()
+            SOURCE_VALUE_DEFAULT -> useDefaultAudioSource()
+            SOURCE_VALUE_CHOOSE_CUSTOM_FILE -> launchAudioPicker()
         }
     }
 
@@ -149,7 +147,7 @@ class MicSpoofingFragment : PackageExtraConfigFragment() {
             title = entry.label
             setIcon(R.drawable.ic_settings_open)
             setOnPreferenceClickListener {
-                launchWavPicker()
+                launchAudioPicker()
                 true
             }
         }
@@ -184,42 +182,19 @@ class MicSpoofingFragment : PackageExtraConfigFragment() {
         }
     }
 
-    private fun launchWavPicker() {
+    private fun launchAudioPicker() {
         try {
-            val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
-                type = MIME_AUDIO_WAV
-                addCategory(Intent.CATEGORY_OPENABLE)
-                putExtra(Intent.EXTRA_MIME_TYPES, arrayOf(MIME_AUDIO_WAV, MIME_AUDIO_X_WAV))
-                putStringArrayListExtra(
-                    Intent.EXTRA_RESTRICTIONS_LIST,
-                    arrayListOf(
-                        DocumentsContract.EXTERNAL_STORAGE_PROVIDER_AUTHORITY,
-                        "com.android.providers.media.documents",
-                        "com.android.providers.downloads.documents",
-                    ),
-                )
-            }
-            chooseWavLauncher.launch(intent)
+            chooseAudioFileLauncher.launch(createPickerIntent())
         } catch (e: ActivityNotFoundException) {
-            Log.w(TAG, "Unable to launch document picker for WAV source selection", e)
+            Log.w(TAG, "Unable to launch document picker for audio source selection", e)
             toastManager.showToast(R.string.mic_spoofing_toast_picker_not_found)
         }
     }
 
-    private fun onChooseWavResult(uri: Uri) {
-        chooseWavJob?.cancel()
-        chooseWavJob = lifecycleScope.launch {
-            if (!validateSelectedWav(uri)) {
-                return@launch
-            }
-
-            val path = withContext(Dispatchers.IO) {
-                convertUriToPath(uri)
-            }
-            if (path == null) {
-                toastManager.showToast(R.string.mic_spoofing_toast_invalid_location)
-                return@launch
-            }
+    private fun onChooseAudioFileResult(uri: Uri) {
+        chooseAudioFileJob?.cancel()
+        chooseAudioFileJob = lifecycleScope.launch {
+            val path = resolveValidatedAudioPath(uri) ?: return@launch
 
             val oldState = getGosPackageState()
             val newConfig = MicSpoofingApi.buildCustomPathConfig(path)
@@ -240,7 +215,7 @@ class MicSpoofingFragment : PackageExtraConfigFragment() {
         }
     }
 
-    private fun useDefaultWav() {
+    private fun useDefaultAudioSource() {
         val packageState = getGosPackageState()
         val applied = applyMicSpoofingConfig(packageState, null)
 
@@ -253,16 +228,19 @@ class MicSpoofingFragment : PackageExtraConfigFragment() {
         update()
     }
 
-    private suspend fun validateSelectedWav(uri: Uri): Boolean {
-        val validationError = withContext(Dispatchers.IO) {
-            validateWavUri(uri)
+    private suspend fun resolveValidatedAudioPath(uri: Uri): String? {
+        val validationResult = withContext(Dispatchers.IO) {
+            validateAudioUri(uri)
         }
-        if (validationError == 0) {
-            return true
+        if (validationResult.errorResId == 0) {
+            return validationResult.path
         }
-        Log.w(TAG, "Selected WAV source failed validation: errorResId=$validationError")
-        toastManager.showToast(validationError)
-        return false
+        Log.w(
+            TAG,
+            "Selected audio source failed validation: errorResId=${validationResult.errorResId}",
+        )
+        toastManager.showToast(validationResult.errorResId)
+        return null
     }
 
     private fun convertUriToPath(uri: Uri): String? {
@@ -275,75 +253,56 @@ class MicSpoofingFragment : PackageExtraConfigFragment() {
         )
     }
 
-    private fun validateWavUri(uri: Uri): Int {
-        val fileSize = getFileSize(uri) ?: return R.string.mic_spoofing_toast_invalid_wav
-        if (fileSize > MAX_WAV_FILE_SIZE_BYTES) {
-            return R.string.mic_spoofing_toast_wav_too_large
+    private fun validateAudioUri(uri: Uri): SelectedAudioValidationResult {
+        val path = convertUriToPath(uri) ?: return SelectedAudioValidationResult(
+            errorResId = R.string.mic_spoofing_toast_invalid_location,
+        )
+
+        val hasReadableContent = isReadableAndNonEmpty(uri) ?: return SelectedAudioValidationResult(
+            errorResId = R.string.mic_spoofing_toast_invalid_audio,
+        )
+        if (!hasReadableContent) {
+            return SelectedAudioValidationResult(
+                errorResId = R.string.mic_spoofing_toast_invalid_audio,
+            )
         }
-        if (!hasWavHeader(uri)) {
-            return R.string.mic_spoofing_toast_invalid_wav
+        val mimeType = getMimeType(uri)
+        if (!isPlausibleAudioFile(mimeType, path)) {
+            return SelectedAudioValidationResult(
+                errorResId = R.string.mic_spoofing_toast_invalid_audio,
+            )
         }
-        return 0
+
+        return SelectedAudioValidationResult(path = path)
     }
 
-    private fun getFileSize(uri: Uri): Long? {
+    private fun isReadableAndNonEmpty(uri: Uri): Boolean? {
         try {
-            context_.contentResolver.openAssetFileDescriptor(uri, "r")?.use { afd ->
-                if (afd.length >= 0) {
-                    return afd.length
-                }
+            val assetLength = context_.contentResolver.openAssetFileDescriptor(uri, "r")?.use { afd ->
+                afd.length.takeIf { it >= 0 }
             }
-
-            context_.contentResolver.openInputStream(uri)?.use { input ->
-                val buffer = ByteArray(8 * 1024)
-                var total = 0L
-                while (true) {
-                    val count = input.read(buffer)
-                    if (count < 0) {
-                        break
-                    }
-                    total += count
-                    if (total > MAX_WAV_FILE_SIZE_BYTES) {
-                        break
-                    }
-                }
-                return total
-            }
+            return probeReadableAndNonEmptyContent(
+                assetLength = assetLength,
+                openInputStream = { context_.contentResolver.openInputStream(uri) },
+            )
         } catch (e: IOException) {
-            Log.w(TAG, "Failed to read selected file size", e)
+            Log.w(TAG, "Failed to verify selected audio readability", e)
             return null
         } catch (e: SecurityException) {
-            Log.w(TAG, "No permission to read selected file size", e)
+            Log.w(TAG, "No permission to verify selected audio readability", e)
             return null
         }
+    }
 
+    private fun getMimeType(uri: Uri): String? {
+        try {
+            return context_.contentResolver.getType(uri)
+        } catch (e: IOException) {
+            Log.w(TAG, "Failed to resolve selected audio MIME type", e)
+        } catch (e: SecurityException) {
+            Log.w(TAG, "No permission to resolve selected audio MIME type", e)
+        }
         return null
-    }
-
-    private fun hasWavHeader(uri: Uri): Boolean {
-        val header = ByteArray(12)
-        try {
-            context_.contentResolver.openInputStream(uri)?.use { input ->
-                var read = 0
-                while (read < header.size) {
-                    val count = input.read(header, read, header.size - read)
-                    if (count < 0) {
-                        Log.w(TAG, "Selected WAV source is too short to contain full header")
-                        return false
-                    }
-                    read += count
-                }
-            } ?: return false
-        } catch (e: IOException) {
-            Log.w(TAG, "Failed to read WAV header", e)
-            return false
-        } catch (e: SecurityException) {
-            Log.w(TAG, "No permission to read WAV header", e)
-            return false
-        }
-
-        return checkMagicBytes(header, 0, RIFF_MAGIC) &&
-                checkMagicBytes(header, 8, WAVE_MAGIC)
     }
 
     private fun applyMicSpoofingConfig(
@@ -355,24 +314,6 @@ class MicSpoofingFragment : PackageExtraConfigFragment() {
             setNotifyUidAfterApply(true)
             apply()
         }
-    }
-
-    private fun checkMagicBytes(
-        header: ByteArray,
-        startIndex: Int,
-        magic: String,
-    ): Boolean {
-        if (header.size < startIndex + magic.length) {
-            return false
-        }
-
-        for (i in magic.indices) {
-            if (header[startIndex + i] != magic[i].code.toByte()) {
-                return false
-            }
-        }
-
-        return true
     }
 
     private fun getFooterSummary(packageState: GosPackageState, enabled: Boolean): CharSequence {
@@ -408,17 +349,15 @@ class MicSpoofingFragment : PackageExtraConfigFragment() {
         val label: String,
     )
 
+    private data class SelectedAudioValidationResult(
+        val path: String? = null,
+        val errorResId: Int = 0,
+    )
+
     private companion object {
         private const val TAG = "MicSpoofingFragment"
 
-        private const val MAX_WAV_FILE_SIZE_BYTES = 100L * 1024 * 1024
-        private const val MIME_AUDIO_WAV = "audio/wav"
-        private const val MIME_AUDIO_X_WAV = "audio/x-wav"
-
         private const val SOURCE_VALUE_DEFAULT = "__default__"
         private const val SOURCE_VALUE_CHOOSE_CUSTOM_FILE = "__choose_custom_file__"
-
-        private const val RIFF_MAGIC = "RIFF"
-        private const val WAVE_MAGIC = "WAVE"
     }
 }

--- a/PermissionController/src/com/android/permissioncontroller/micspoofing/MicSpoofingLinks.kt
+++ b/PermissionController/src/com/android/permissioncontroller/micspoofing/MicSpoofingLinks.kt
@@ -1,0 +1,75 @@
+package com.android.permissioncontroller.micspoofing
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.pm.GosPackageState
+import android.ext.micspoofing.MicSpoofingApi
+import android.os.UserHandle
+import android.widget.Button
+import androidx.annotation.RequiresPermission
+import com.android.permissioncontroller.R
+import com.android.permissioncontroller.permission.ui.GrantPermissionsActivity
+import com.android.permissioncontroller.permission.ui.handheld.ExtraPermissionLink
+
+object MicSpoofingLinks : ExtraPermissionLink() {
+
+    private val PERMISSION_GROUPS = setOf(
+        Manifest.permission_group.MICROPHONE,
+    )
+
+    private fun isMicrophonePermissionGroup(name: String): Boolean {
+        return PERMISSION_GROUPS.contains(name)
+    }
+
+    override fun isVisible(
+        ctx: Context,
+        groupName: String,
+        packageName: String,
+        user: UserHandle,
+    ): Boolean {
+        return isMicrophonePermissionGroup(groupName)
+    }
+
+    override fun setupDialogButton(button: Button) {
+        button.setText(R.string.setup_microphone_spoofing)
+    }
+
+    override fun onDialogButtonClick(activity: GrantPermissionsActivity, packageName: String) {
+        val intent = createConfigActivityIntent(packageName)
+        @Suppress("DEPRECATION")
+        activity.startActivityForResult(
+            intent,
+            GrantPermissionsActivity.REQ_CODE_SETUP_MICROPHONE_SPOOFING,
+        )
+    }
+
+    override fun getSettingsDeniedRadioButtonSuffix(
+        ctx: Context,
+        packageState: GosPackageState,
+    ): String? {
+        if (!isMicSpoofingEnabled(packageState)) {
+            return null
+        }
+
+        val micSpoofing = ctx.getString(R.string.microphone_spoofing)
+        return " (+ $micSpoofing)"
+    }
+
+    override fun getSettingsLinkText(ctx: Context): CharSequence {
+        return ctx.getText(R.string.setup_microphone_spoofing)
+    }
+
+    override fun getSettingsLinkIconResId(ctx: Context): Int {
+        return R.drawable.ic_settings
+    }
+
+    @RequiresPermission(Manifest.permission.INTERACT_ACROSS_USERS)
+    override fun onSettingsLinkClick(ctx: Context, packageName: String, user: UserHandle) {
+        ctx.startActivityAsUser(createConfigActivityIntent(packageName), user)
+    }
+
+    private fun createConfigActivityIntent(packageName: String): Intent {
+        return MicSpoofingApi.createConfigActivityIntent(packageName)
+    }
+}

--- a/PermissionController/src/com/android/permissioncontroller/micspoofing/MicSpoofingPathUtils.kt
+++ b/PermissionController/src/com/android/permissioncontroller/micspoofing/MicSpoofingPathUtils.kt
@@ -1,0 +1,53 @@
+@file:JvmName("MicSpoofingPathUtils")
+
+package com.android.permissioncontroller.micspoofing
+
+import android.content.Context
+import android.net.Uri
+import android.os.storage.StorageVolume
+import android.util.Log
+import com.android.permissioncontroller.ext.resolveFileUriToPath
+import com.android.permissioncontroller.ext.storageVolumeForPath
+import com.android.permissioncontroller.ext.validatePathBasics
+import java.io.File
+
+private const val TAG = "MicSpoofingPathUtils"
+
+fun fileUriToPath(
+    context: Context,
+    uri: Uri,
+    cachedVolumes: List<StorageVolume>?,
+): String? {
+    val unverifiedPath = resolveFileUriToPath(context, uri)
+
+    if (!validateSourcePath(unverifiedPath, context, cachedVolumes)) {
+        Log.w(TAG, "Invalid mic spoofing path $unverifiedPath")
+        return null
+    }
+
+    return unverifiedPath
+}
+
+private fun validateSourcePath(
+    path: String?,
+    context: Context,
+    cachedVolumes: List<StorageVolume>?,
+): Boolean {
+    if (path == null) {
+        return false
+    }
+
+    if (!validatePathBasics(path)) {
+        return false
+    }
+
+    val userId = context.user.identifier
+    val expectedPrefix = "/storage/emulated/$userId/"
+    if (!path.startsWith(expectedPrefix)) {
+        return false
+    }
+
+    val volume = storageVolumeForPath(context, File(path), cachedVolumes) ?: return false
+
+    return volume.isPrimary
+}

--- a/PermissionController/src/com/android/permissioncontroller/micspoofing/MicSpoofingUtils.kt
+++ b/PermissionController/src/com/android/permissioncontroller/micspoofing/MicSpoofingUtils.kt
@@ -1,0 +1,15 @@
+@file:JvmName("MicSpoofingUtils")
+
+package com.android.permissioncontroller.micspoofing
+
+import android.content.pm.GosPackageState
+import android.content.pm.GosPackageStateFlag
+import android.os.UserHandle
+
+fun isMicSpoofingEnabled(packageName: String, user: UserHandle): Boolean {
+    return isMicSpoofingEnabled(GosPackageState.get(packageName, user))
+}
+
+fun isMicSpoofingEnabled(packageState: GosPackageState): Boolean {
+    return packageState.hasFlag(GosPackageStateFlag.MIC_SPOOFING_ENABLED)
+}

--- a/PermissionController/src/com/android/permissioncontroller/micspoofing/MicSpoofingWrapperFragment.kt
+++ b/PermissionController/src/com/android/permissioncontroller/micspoofing/MicSpoofingWrapperFragment.kt
@@ -1,0 +1,8 @@
+package com.android.permissioncontroller.micspoofing
+
+import androidx.preference.PreferenceFragmentCompat
+import com.android.permissioncontroller.permission.ui.handheld.PermissionsCollapsingToolbarBaseFragment
+
+class MicSpoofingWrapperFragment : PermissionsCollapsingToolbarBaseFragment() {
+    override fun createPreferenceFragment(): PreferenceFragmentCompat = MicSpoofingFragment()
+}

--- a/PermissionController/src/com/android/permissioncontroller/permission/ui/GrantPermissionsActivity.java
+++ b/PermissionController/src/com/android/permissioncontroller/permission/ui/GrantPermissionsActivity.java
@@ -89,6 +89,7 @@ import com.android.permissioncontroller.DeviceUtils;
 import com.android.permissioncontroller.R;
 import com.android.permissioncontroller.cscopes.ContactScopesUtils;
 import com.android.permissioncontroller.ecm.EnhancedConfirmationStatsLogUtils;
+import com.android.permissioncontroller.micspoofing.MicSpoofingUtils;
 import com.android.permissioncontroller.permission.model.livedatatypes.LightPermGroupInfo;
 import com.android.permissioncontroller.permission.ui.auto.GrantPermissionsAutoViewHandler;
 import com.android.permissioncontroller.permission.ui.handheld.ExtraPermissionLinkKt;
@@ -1046,6 +1047,7 @@ public class GrantPermissionsActivity extends SettingsActivity
 
     public static final int REQ_CODE_SETUP_STORAGE_SCOPES = 100;
     public static final int REQ_CODE_SETUP_CONTACT_SCOPES = 101;
+    public static final int REQ_CODE_SETUP_MICROPHONE_SPOOFING = 102;
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
@@ -1066,6 +1068,13 @@ public class GrantPermissionsActivity extends SettingsActivity
 
         if (requestCode == REQ_CODE_SETUP_CONTACT_SCOPES) {
             if (ContactScopesUtils.isContactScopesEnabled(mTargetPackage, getUser())) {
+                setResultAndFinish();
+            }
+            return;
+        }
+
+        if (requestCode == REQ_CODE_SETUP_MICROPHONE_SPOOFING) {
+            if (MicSpoofingUtils.isMicSpoofingEnabled(mTargetPackage, getUser())) {
                 setResultAndFinish();
             }
             return;

--- a/PermissionController/src/com/android/permissioncontroller/permission/ui/handheld/ExtraPermissionLink.kt
+++ b/PermissionController/src/com/android/permissioncontroller/permission/ui/handheld/ExtraPermissionLink.kt
@@ -23,6 +23,8 @@ abstract class ExtraPermissionLink {
 
     abstract fun getSettingsLinkText(ctx: Context): CharSequence
 
+    open fun getSettingsLinkIconResId(ctx: Context): Int = 0
+
     abstract fun onSettingsLinkClick(ctx: Context, packageName: String, user: UserHandle)
 }
 

--- a/PermissionController/src/com/android/permissioncontroller/permission/ui/handheld/ExtraPermissionLink.kt
+++ b/PermissionController/src/com/android/permissioncontroller/permission/ui/handheld/ExtraPermissionLink.kt
@@ -5,6 +5,7 @@ import android.content.pm.GosPackageState
 import android.os.UserHandle
 import android.widget.Button
 import com.android.permissioncontroller.cscopes.ContactScopesLinks
+import com.android.permissioncontroller.micspoofing.MicSpoofingLinks
 import com.android.permissioncontroller.permission.ui.GrantPermissionsActivity
 import com.android.permissioncontroller.sscopes.StorageScopesLinks
 
@@ -31,6 +32,7 @@ abstract class ExtraPermissionLink {
 private val allExtraPermissionLinks = arrayOf(
         StorageScopesLinks,
         ContactScopesLinks,
+        MicSpoofingLinks,
 )
 
 fun getExtraPermissionLink(ctx: Context, packageName: String, user: UserHandle, groupName: String): ExtraPermissionLink? {

--- a/PermissionController/src/com/android/permissioncontroller/permission/ui/handheld/v36/AppPermissionFragment.java
+++ b/PermissionController/src/com/android/permissioncontroller/permission/ui/handheld/v36/AppPermissionFragment.java
@@ -759,6 +759,14 @@ public class AppPermissionFragment extends SettingsWithLargeHeader
         }
 
         mExtraLink1.setTitle(link.getSettingsLinkText(ctx));
+        int settingsLinkIcon = link.getSettingsLinkIconResId(ctx);
+        if (settingsLinkIcon != 0) {
+            mExtraLink1.setIcon(settingsLinkIcon);
+            mExtraLink1.setIconSpaceReserved(true);
+        } else {
+            mExtraLink1.setIcon(null);
+            mExtraLink1.setIconSpaceReserved(false);
+        }
         mExtraLink1.setOnPreferenceClickListener(p -> {
             link.onSettingsLinkClick(p.getContext(), mPackageName, mUser);
             return true;

--- a/PermissionController/src/com/android/permissioncontroller/sscopes/StorageScopesUtils.java
+++ b/PermissionController/src/com/android/permissioncontroller/sscopes/StorageScopesUtils.java
@@ -25,82 +25,39 @@ import android.content.pm.GosPackageState;
 import android.content.pm.GosPackageStateFlag;
 import android.net.Uri;
 import android.os.Bundle;
-import android.os.ParcelFileDescriptor;
 import android.os.UserHandle;
-import android.os.storage.StorageManager;
 import android.os.storage.StorageVolume;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
-import android.system.Os;
 import android.util.Log;
 
 import androidx.annotation.Nullable;
 
 import com.android.permissioncontroller.ext.ScopesUtils;
+import com.android.permissioncontroller.ext.StoragePathUtils;
 import com.android.permissioncontroller.permission.utils.KotlinUtils;
 
 import java.io.File;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
-import static com.android.permissioncontroller.ext.StringUtils.isUtf16;
-
 public class StorageScopesUtils {
     private static final String TAG = "StorageScopesUtils";
-
-    private static final String MEDIA_PROVIDER_PACKAGE = "com.android.providers.media.module";
-
-    private static final int MAX_SCOPE_PATH_LENGTH_IN_UTF8_BYTES = 4096; // default PATH_MAX value
 
     private StorageScopesUtils() {}
 
     private static boolean validateScopePath(@Nullable String path, Context context, @Nullable List<StorageVolume> cachedVolumes) {
-        if (path == null) {
+        if (!StoragePathUtils.validatePathBasics(path)) {
             return false;
         }
 
-        // Java String content isn't guaranteed to be a valid UTF-16 sequence
-        if (!isUtf16(path)) {
-            return false;
-        }
-
-        if (path.indexOf('\0') >= 0) {
-            return false;
-        }
-
-        String[] components = path.split("/");
-
-        if (components.length < 2) {
-            return false;
-        }
-
-        if (components[0].length() != 0) {
-            // first component ("" before initial "/") should be empty
-            return false;
-        }
-
-        for (int i = 1; i < components.length; ++i) {
-            if (components[i].length() == 0) {
-                return false;
-            }
-        }
-
-        if (path.getBytes(StandardCharsets.UTF_8).length > MAX_SCOPE_PATH_LENGTH_IN_UTF8_BYTES) {
-            return false;
-        }
-
-        if (StorageScopesUtils.storageVolumeForPath(context, new File(path), cachedVolumes) == null) {
-            return false;
-        }
-
-        return true;
+        return StoragePathUtils.storageVolumeForPath(context, new File(path), cachedVolumes) != null;
     }
 
     static String pathToUiLabel(Context ctx, List<StorageVolume> volumes, File path) {
-        StorageVolume volume = storageVolumeForPath(ctx, path, volumes);
+        StorageVolume volume = StoragePathUtils.storageVolumeForPath(ctx, path, volumes);
 
         if (volume != null) {
             String volumeName = volume.isPrimary() ?
@@ -116,38 +73,6 @@ public class StorageScopesUtils {
         }
 
         return path.getAbsolutePath();
-    }
-
-    @Nullable
-    private static StorageVolume storageVolumeForPath(Context ctx, File file, List<StorageVolume> cachedVolumes) {
-        List<StorageVolume> volumes = (cachedVolumes != null) ?
-                cachedVolumes :
-                ctx.getSystemService(StorageManager.class).getStorageVolumes();
-
-        for (StorageVolume volume : volumes) {
-            File volumeRoot = volume.getDirectory();
-
-            if (volumeRoot == null) {
-                continue;
-            }
-
-            if (dirContainsOrEquals(volumeRoot, file)) {
-                return volume;
-            }
-        }
-        return null;
-    }
-
-    private static boolean dirContainsOrEquals(File dir, File file) {
-        for (;;) {
-            if (file.equals(dir)) {
-                return true;
-            }
-            file = file.getParentFile();
-            if (file == null) {
-                return false;
-            }
-        }
     }
 
     static String dirUriToPath(Context ctx, Uri uri) {
@@ -192,25 +117,7 @@ public class StorageScopesUtils {
                 unverifiedPath = res.getString(id);
             }
         } else {
-            try (ParcelFileDescriptor pfd = ctx.getContentResolver().openFile(uri, "r", null)) {
-                String fdPath = "/proc/self/fd/" + pfd.getFd();
-
-                String realpath = Os.readlink(fdPath);
-
-                if (realpath.startsWith("/mnt/user/")) {
-                    // devices that launched with Android 11+ mount shared storage differently
-                    realpath = realpath.replaceFirst("/mnt/user/" + UserHandle.myUserId() + "/", "/storage/");
-                }
-
-                if (new File(realpath).isFile()) {
-                    unverifiedPath = realpath;
-                } else {
-                    Log.d(TAG, realpath + " is not a file, " + Os.stat(realpath));
-                }
-            } catch (Exception e) {
-                Log.d(TAG, "unable to convert uri " + uri + " to path", e);
-                return null;
-            }
+            unverifiedPath = StoragePathUtils.resolveFileUriToPath(ctx, uri);
         }
 
         if (validateScopePath(unverifiedPath, ctx, cachedVolumes)) {

--- a/PermissionController/tests/inprocess/src/com/android/permissioncontroller/ext/StoragePathUtilsTest.kt
+++ b/PermissionController/tests/inprocess/src/com/android/permissioncontroller/ext/StoragePathUtilsTest.kt
@@ -1,0 +1,134 @@
+package com.android.permissioncontroller.ext
+
+import android.content.ContextWrapper
+import android.net.Uri
+import android.os.storage.StorageManager
+import android.os.storage.StorageVolume
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class StoragePathUtilsTest {
+
+    private val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test
+    fun validatePathBasics_validAbsolutePath_returnsTrue() {
+        assertThat(validatePathBasics("/storage/emulated/0/Music/test.wav")).isTrue()
+    }
+
+    @Test
+    fun validatePathBasics_null_returnsFalse() {
+        assertThat(validatePathBasics(null)).isFalse()
+    }
+
+    @Test
+    fun validatePathBasics_relativePath_returnsFalse() {
+        assertThat(validatePathBasics("storage/emulated/0/Music/test.wav")).isFalse()
+    }
+
+    @Test
+    fun validatePathBasics_emptyComponent_returnsFalse() {
+        assertThat(validatePathBasics("/storage//emulated/0/test.wav")).isFalse()
+    }
+
+    @Test
+    fun validatePathBasics_containsNul_returnsFalse() {
+        assertThat(validatePathBasics("/storage/emulated/0/test\u0000.wav")).isFalse()
+    }
+
+    @Test
+    fun validatePathBasics_overMaxUtf8Length_returnsFalse() {
+        val tooLong = "/" + "a".repeat(4097)
+
+        assertThat(validatePathBasics(tooLong)).isFalse()
+    }
+
+    @Test
+    fun storageVolumeForPath_withMatchingCachedVolumes_returnsVolume() {
+        val file = createTempExternalFile("storage-volume-match")
+        try {
+            val volume = storageVolumeForPath(targetContext, file, storageVolumes())
+
+            assertThat(volume).isNotNull()
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun storageVolumeForPath_withEmptyCachedVolumes_returnsNull() {
+        val file = createTempExternalFile("storage-volume-empty")
+        try {
+            val volume = storageVolumeForPath(targetContext, file, emptyList())
+
+            assertThat(volume).isNull()
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun storageVolumeForPath_withoutStorageManager_returnsNull() {
+        val contextWithoutStorageManager = object : ContextWrapper(targetContext) {
+            override fun getSystemService(name: String): Any? {
+                if (name == android.content.Context.STORAGE_SERVICE) {
+                    return null
+                }
+                return super.getSystemService(name)
+            }
+        }
+
+        val volume = storageVolumeForPath(
+            contextWithoutStorageManager,
+            File("/storage/emulated/0"),
+            null,
+        )
+
+        assertThat(volume).isNull()
+    }
+
+    @Test
+    fun resolveFileUriToPath_existingFileUri_returnsFilePath() {
+        val file = createTempExternalFile("resolve-file-uri")
+        try {
+            val resolvedPath = resolveFileUriToPath(targetContext, Uri.fromFile(file))
+
+            assertThat(resolvedPath).isNotNull()
+            assertThat(File(requireNotNull(resolvedPath)).canonicalFile)
+                .isEqualTo(file.canonicalFile)
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun resolveFileUriToPath_invalidUri_returnsNull() {
+        val resolvedPath = resolveFileUriToPath(
+            targetContext,
+            Uri.parse("content://does.not.exist/invalid")
+        )
+
+        assertThat(resolvedPath).isNull()
+    }
+
+    private fun createTempExternalFile(prefix: String): File {
+        val externalDir = checkNotNull(targetContext.getExternalFilesDir(null)) {
+            "External files directory must be available"
+        }
+        return File
+            .createTempFile(prefix, ".txt", externalDir)
+            .apply { writeText("test") }
+    }
+
+    private fun storageVolumes(): List<StorageVolume> {
+        val storageManager = checkNotNull(
+            targetContext.getSystemService(StorageManager::class.java)
+        )
+        return storageManager.storageVolumes
+    }
+}

--- a/PermissionController/tests/inprocess/src/com/android/permissioncontroller/micspoofing/MicSpoofingAudioFileUtilsTest.kt
+++ b/PermissionController/tests/inprocess/src/com/android/permissioncontroller/micspoofing/MicSpoofingAudioFileUtilsTest.kt
@@ -1,0 +1,125 @@
+package com.android.permissioncontroller.micspoofing
+
+import android.content.Intent
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.android.permissioncontroller.R
+import com.google.common.truth.Truth.assertThat
+import java.io.ByteArrayInputStream
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MicSpoofingAudioFileUtilsTest {
+
+    private val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test
+    fun createPickerIntent_includesGenericAudioMimeTypes() {
+        val intent = createPickerIntent()
+
+        assertThat(intent.action).isEqualTo(Intent.ACTION_OPEN_DOCUMENT)
+        assertThat(intent.type).isEqualTo(AUDIO_PICKER_MIME_TYPE)
+        assertThat(requireNotNull(intent.categories)).contains(Intent.CATEGORY_OPENABLE)
+        assertThat(requireNotNull(intent.getStringArrayExtra(Intent.EXTRA_MIME_TYPES)).asList())
+            .containsAtLeast(
+                "audio/wav",
+                "audio/x-wav",
+                "audio/mpeg",
+                "audio/ogg",
+                "audio/flac",
+                "audio/mp4",
+                "audio/aac",
+                "audio/x-m4a",
+            )
+        assertThat(
+            requireNotNull(
+                intent.getStringArrayListExtra(Intent.EXTRA_RESTRICTIONS_LIST),
+            ),
+        ).containsAtLeast(
+            "com.android.externalstorage.documents",
+            "com.android.providers.media.documents",
+            "com.android.providers.downloads.documents",
+        )
+    }
+
+    @Test
+    fun isPlausibleAudioFile_acceptsSupportedAudioMimeWithoutWavSpecificChecks() {
+        val plausible = isPlausibleAudioFile(
+            mimeType = "audio/flac",
+            path = "/storage/emulated/0/Download/not-a-wav.bin",
+        )
+
+        assertThat(plausible).isTrue()
+    }
+
+    @Test
+    fun isPlausibleAudioFile_acceptsSupportedAudioExtensionWhenMimeIsGeneric() {
+        val plausible = isPlausibleAudioFile(
+            mimeType = "application/octet-stream",
+            path = "/storage/emulated/0/Music/test-tone.m4a",
+        )
+
+        assertThat(plausible).isTrue()
+    }
+
+    @Test
+    fun isPlausibleAudioFile_rejectsUnknownMimeAndExtension() {
+        val plausible = isPlausibleAudioFile(
+            mimeType = "application/pdf",
+            path = "/storage/emulated/0/Download/document.pdf",
+        )
+
+        assertThat(plausible).isFalse()
+    }
+
+    @Test
+    fun probeReadableAndNonEmptyContent_readsUnknownLengthStream() {
+        var openInputStreamCalls = 0
+
+        val readable = probeReadableAndNonEmptyContent(assetLength = -1L) {
+            openInputStreamCalls += 1
+            ByteArrayInputStream(byteArrayOf(0x2A))
+        }
+
+        assertThat(readable).isTrue()
+        assertThat(openInputStreamCalls).isEqualTo(1)
+    }
+
+    @Test
+    fun probeReadableAndNonEmptyContent_rejectsEmptyUnknownLengthStream() {
+        val readable = probeReadableAndNonEmptyContent(assetLength = -1L) {
+            ByteArrayInputStream(byteArrayOf())
+        }
+
+        assertThat(readable).isFalse()
+    }
+
+    @Test
+    fun probeReadableAndNonEmptyContent_usesKnownLengthWithoutOpeningStream() {
+        var openInputStreamCalls = 0
+
+        val readable = probeReadableAndNonEmptyContent(assetLength = 4L) {
+            openInputStreamCalls += 1
+            ByteArrayInputStream(byteArrayOf(0x2A))
+        }
+
+        assertThat(readable).isTrue()
+        assertThat(openInputStreamCalls).isEqualTo(0)
+    }
+
+    @Test
+    fun micSpoofingStrings_doNotMentionWav() {
+        assertThat(targetContext.getString(R.string.mic_spoofing_source_choose_custom_file))
+            .isEqualTo("Choose custom audio file")
+        assertThat(targetContext.getString(R.string.mic_spoofing_source_custom_fallback))
+            .isEqualTo("Custom audio file")
+        assertThat(targetContext.getString(R.string.mic_spoofing_footer_disabled))
+            .isEqualTo(
+                "When enabled, Microphone Spoofing replaces app microphone input with " +
+                    "silence or audio from a custom audio file.",
+            )
+        assertThat(targetContext.getString(R.string.mic_spoofing_toast_invalid_audio))
+            .isEqualTo("Selected file is not a supported audio file")
+    }
+}

--- a/PermissionController/tests/inprocess/src/com/android/permissioncontroller/micspoofing/MicSpoofingLinksTest.kt
+++ b/PermissionController/tests/inprocess/src/com/android/permissioncontroller/micspoofing/MicSpoofingLinksTest.kt
@@ -1,0 +1,171 @@
+package com.android.permissioncontroller.micspoofing
+
+import android.Manifest
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import android.content.pm.GosPackageState
+import android.content.pm.GosPackageStateFlag
+import android.os.Parcel
+import android.os.UserHandle
+import android.widget.Button
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.android.permissioncontroller.R
+import com.android.permissioncontroller.permission.ui.GrantPermissionsActivity
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MicSpoofingLinksTest {
+
+    private val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test
+    fun isVisible_forMicrophoneGroup_returnsTrue() {
+        val visible = MicSpoofingLinks.isVisible(
+            targetContext,
+            Manifest.permission_group.MICROPHONE,
+            "com.example.app",
+            UserHandle.SYSTEM,
+        )
+
+        assertThat(visible).isTrue()
+    }
+
+    @Test
+    fun isVisible_forNonMicrophoneGroup_returnsFalse() {
+        val visible = MicSpoofingLinks.isVisible(
+            targetContext,
+            Manifest.permission_group.CAMERA,
+            "com.example.app",
+            UserHandle.SYSTEM,
+        )
+
+        assertThat(visible).isFalse()
+    }
+
+    @Test
+    fun setupDialogButton_setsMicrophoneSpoofingText() {
+        val button = Button(targetContext)
+
+        MicSpoofingLinks.setupDialogButton(button)
+
+        assertThat(button.text.toString())
+            .isEqualTo(targetContext.getString(R.string.setup_microphone_spoofing))
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun onDialogButtonClick_startsMicSpoofingActivityForResult() {
+        val packageName = "com.example.app"
+        var activity: RecordingGrantPermissionsActivity? = null
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            val testActivity = RecordingGrantPermissionsActivity()
+            MicSpoofingLinks.onDialogButtonClick(testActivity, packageName)
+            activity = testActivity
+        }
+
+        val recordedActivity = requireNotNull(activity)
+
+        assertIntentTargetsMicSpoofing(recordedActivity.startedIntent, packageName)
+        assertThat(recordedActivity.startedRequestCode)
+            .isEqualTo(GrantPermissionsActivity.REQ_CODE_SETUP_MICROPHONE_SPOOFING)
+    }
+
+    @Test
+    fun getSettingsDeniedRadioButtonSuffix_enabled_returnsExpectedSuffix() {
+        val packageState = createPackageState(1L shl GosPackageStateFlag.MIC_SPOOFING_ENABLED)
+
+        val suffix = MicSpoofingLinks
+            .getSettingsDeniedRadioButtonSuffix(targetContext, packageState)
+
+        assertThat(suffix).isEqualTo(" (+ ${targetContext.getString(R.string.microphone_spoofing)})")
+    }
+
+    @Test
+    fun getSettingsDeniedRadioButtonSuffix_disabled_returnsNull() {
+        val packageState = createPackageState(0L)
+
+        val suffix = MicSpoofingLinks
+            .getSettingsDeniedRadioButtonSuffix(targetContext, packageState)
+
+        assertThat(suffix).isNull()
+    }
+
+    @Test
+    fun getSettingsLinkText_returnsMicrophoneSpoofingText() {
+        assertThat(MicSpoofingLinks.getSettingsLinkText(targetContext).toString())
+            .isEqualTo(targetContext.getString(R.string.setup_microphone_spoofing))
+    }
+
+    @Test
+    fun onSettingsLinkClick_startsMicSpoofingActivity() {
+        val context = RecordingContext(targetContext)
+        val user = UserHandle.of(10)
+        val packageName = "com.example.app"
+
+        MicSpoofingLinks.onSettingsLinkClick(context, packageName, user)
+
+        assertIntentTargetsMicSpoofing(context.startedIntent, packageName)
+        assertThat(context.startedUser).isEqualTo(user)
+    }
+
+    private fun createPackageState(flagStorage1: Long): GosPackageState {
+        return Parcel.obtain().useParcel { parcel ->
+            parcel.writeInt(REGULAR_GOS_PACKAGE_STATE_TYPE)
+            parcel.writeLong(flagStorage1)
+            parcel.writeLong(0L)
+            parcel.writeByteArray(null)
+            parcel.writeByteArray(null)
+            parcel.writeByteArray(null)
+            parcel.writeInt(0)
+            parcel.setDataPosition(0)
+            GosPackageState.CREATOR.createFromParcel(parcel)
+        }
+    }
+
+    private fun assertIntentTargetsMicSpoofing(intent: Intent?, packageName: String) {
+        requireNotNull(intent)
+        assertThat(intent.component?.packageName).isEqualTo("com.android.permissioncontroller")
+        assertThat(intent.component?.className)
+            .isEqualTo("com.android.permissioncontroller.micspoofing.MicSpoofingActivity")
+        assertThat(intent.getStringExtra(Intent.EXTRA_PACKAGE_NAME)).isEqualTo(packageName)
+    }
+
+    private class RecordingGrantPermissionsActivity : GrantPermissionsActivity() {
+        var startedIntent: Intent? = null
+        var startedRequestCode = -1
+
+        @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
+        override fun startActivityForResult(intent: Intent, requestCode: Int) {
+            startedIntent = intent
+            startedRequestCode = requestCode
+        }
+    }
+
+    private class RecordingContext(base: Context) : ContextWrapper(base) {
+        var startedIntent: Intent? = null
+        var startedUser: UserHandle? = null
+
+        override fun startActivityAsUser(intent: Intent, user: UserHandle) {
+            startedIntent = intent
+            startedUser = user
+        }
+    }
+
+    private fun Parcel.useParcel(block: (Parcel) -> GosPackageState): GosPackageState {
+        return try {
+            block(this)
+        } finally {
+            recycle()
+        }
+    }
+
+    companion object {
+        // Hidden TYPE_REGULAR value used by GosPackageState parcel format.
+        private const val REGULAR_GOS_PACKAGE_STATE_TYPE = 2
+    }
+}

--- a/PermissionController/tests/inprocess/src/com/android/permissioncontroller/micspoofing/MicSpoofingPathUtilsTest.kt
+++ b/PermissionController/tests/inprocess/src/com/android/permissioncontroller/micspoofing/MicSpoofingPathUtilsTest.kt
@@ -1,0 +1,86 @@
+package com.android.permissioncontroller.micspoofing
+
+import android.net.Uri
+import android.os.storage.StorageManager
+import android.os.storage.StorageVolume
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MicSpoofingPathUtilsTest {
+
+    private val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test
+    fun fileUriToPath_validExternalFile_returnsPath() {
+        val file = createTempExternalFile("mic-spoofing-valid")
+        try {
+            val path = fileUriToPath(targetContext, Uri.fromFile(file), storageVolumes())
+
+            assertThat(path).isNotNull()
+            assertThat(path).startsWith("/storage/emulated/${targetContext.user.identifier}/")
+            assertThat(File(requireNotNull(path)).canonicalFile).isEqualTo(file.canonicalFile)
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun fileUriToPath_withEmptyCachedVolumes_returnsNull() {
+        val file = createTempExternalFile("mic-spoofing-empty-volumes")
+        try {
+            val path = fileUriToPath(targetContext, Uri.fromFile(file), emptyList())
+
+            assertThat(path).isNull()
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun fileUriToPath_nonExternalFile_returnsNull() {
+        val file = createTempInternalFile("mic-spoofing-internal")
+        try {
+            val path = fileUriToPath(targetContext, Uri.fromFile(file), storageVolumes())
+
+            assertThat(path).isNull()
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun fileUriToPath_invalidUri_returnsNull() {
+        val path =
+            fileUriToPath(
+                targetContext,
+                Uri.parse("content://does.not.exist/mic-spoofing-invalid"),
+                storageVolumes(),
+            )
+
+        assertThat(path).isNull()
+    }
+
+    private fun createTempExternalFile(prefix: String): File {
+        val externalDir = checkNotNull(targetContext.getExternalFilesDir(null)) {
+            "External files directory must be available"
+        }
+        return File.createTempFile(prefix, ".wav", externalDir).apply { writeText("audio") }
+    }
+
+    private fun createTempInternalFile(prefix: String): File {
+        return File.createTempFile(prefix, ".wav", targetContext.cacheDir)
+            .apply { writeText("audio") }
+    }
+
+    private fun storageVolumes(): List<StorageVolume> {
+        val storageManager = checkNotNull(
+            targetContext.getSystemService(StorageManager::class.java)
+        )
+        return storageManager.storageVolumes
+    }
+}

--- a/PermissionController/tests/inprocess/src/com/android/permissioncontroller/permission/ui/handheld/ExtraPermissionLinkTest.kt
+++ b/PermissionController/tests/inprocess/src/com/android/permissioncontroller/permission/ui/handheld/ExtraPermissionLinkTest.kt
@@ -1,0 +1,40 @@
+package com.android.permissioncontroller.permission.ui.handheld
+
+import android.Manifest
+import android.os.UserHandle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.android.permissioncontroller.micspoofing.MicSpoofingLinks
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ExtraPermissionLinkTest {
+
+    private val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test
+    fun getExtraPermissionLink_microphoneGroup_returnsMicSpoofingLink() {
+        val link = getExtraPermissionLink(
+            targetContext,
+            "com.example.app",
+            UserHandle.SYSTEM,
+            Manifest.permission_group.MICROPHONE,
+        )
+
+        assertThat(link).isEqualTo(MicSpoofingLinks)
+    }
+
+    @Test
+    fun getExtraPermissionLink_unrelatedGroup_returnsNull() {
+        val link = getExtraPermissionLink(
+            targetContext,
+            "com.example.app",
+            UserHandle.SYSTEM,
+            Manifest.permission_group.CAMERA,
+        )
+
+        assertThat(link).isNull()
+    }
+}


### PR DESCRIPTION
Implements https://github.com/GrapheneOS/os-issue-tracker/issues/2133

Adds PermissionController UI and flows for mic spoofing configuration.

**Tests:**
```shell
atest -c \
  PermissionControllerInProcessTests:com.android.permissioncontroller.micspoofing.MicSpoofingLinksTest \
  PermissionControllerInProcessTests:com.android.permissioncontroller.permission.ui.handheld.ExtraPermissionLinkTest
```