### PR TITLE
enable config_enableExpressiveDesignInSafetyCenter by default

### DIFF
--- a/PermissionController/res/values/bools.xml
+++ b/PermissionController/res/values/bools.xml
@@ -31,5 +31,5 @@
     <bool name="config_enableExpressiveDesignInEnhancedConfirmationDialog">true</bool>
     <!-- config for opting out of expressive Safety Center. This has no effect currently
     but may be enabled in a subsequent release -->
-    <bool name="config_enableExpressiveDesignInSafetyCenter">false</bool>
+    <bool name="config_enableExpressiveDesignInSafetyCenter">true</bool>
 </resources>


### PR DESCRIPTION
stallion-BD6A.251031.001.A4 didn't have an overlay for this. Simpler to just turn this on everywhere, since all the other Pixel devices have this overlaid to true.